### PR TITLE
feat: implement Vosk wake word engine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,11 @@ wakeword = [
     "openwakeword>=0.4.0",
 ]
 
+# Vosk offline speech recognition / wake word
+vosk = [
+    "vosk>=0.3.45",
+]
+
 # Speaker diarization / voice identification
 diarization = [
     "resemblyzer>=0.1.1",
@@ -91,7 +96,7 @@ diarization = [
 
 # All optional extras
 all = [
-    "champi-stt[torch,imgui,nlp,wakeword,diarization]",
+    "champi-stt[torch,imgui,nlp,wakeword,vosk,diarization]",
 ]
 
 # Development tools

--- a/src/champi_stt/assistant/wakeword/__init__.py
+++ b/src/champi_stt/assistant/wakeword/__init__.py
@@ -5,9 +5,9 @@ Wake Word Detection System
 Provides wake word/hotword detection for voice assistants.
 
 Supported engines:
-- WhisperWakeWord (recommended, uses WhisperLive STT)
-- OpenWakeWord (free and open source)
-- Vosk (open source, general ASR)
+- WhisperWakeWord (uses WhisperLive STT)
+- Porcupine (high accuracy, requires API key)
+- Vosk (offline, no API key required)
 """
 
 from champi_stt.assistant.wakeword.base import (
@@ -16,6 +16,7 @@ from champi_stt.assistant.wakeword.base import (
     WakeWordConfig,
     WakeWordEvent,
 )
+from champi_stt.assistant.wakeword.vosk import VoskWakeWord
 from champi_stt.assistant.wakeword.whisper import WhisperWakeWordDetector
 
 __all__ = [
@@ -23,5 +24,6 @@ __all__ = [
     "BaseWakeWordEngine",
     "WakeWordConfig",
     "WakeWordEvent",
+    "VoskWakeWord",
     "WhisperWakeWordDetector",
 ]

--- a/src/champi_stt/assistant/wakeword/vosk.py
+++ b/src/champi_stt/assistant/wakeword/vosk.py
@@ -1,0 +1,144 @@
+"""
+Vosk-based wake word / keyword spotting engine.
+
+Uses Vosk's KaldiRecognizer with grammar-constrained decoding to detect
+specific keywords without requiring an API key or internet connection.
+"""
+
+import json
+
+import numpy as np
+from loguru import logger
+
+from champi_stt.assistant.wakeword.base import BaseWakeWordEngine, WakeWordConfig
+
+try:
+    from vosk import KaldiRecognizer, Model  # type: ignore[import-untyped]
+
+    VOSK_AVAILABLE = True
+except ImportError:
+    VOSK_AVAILABLE = False
+
+    class Model:  # type: ignore[no-redef]
+        pass
+
+    class KaldiRecognizer:  # type: ignore[no-redef]
+        pass
+
+
+class VoskWakeWord(BaseWakeWordEngine):
+    """
+    Vosk-based keyword spotting for offline wake word detection.
+
+    Unlike Porcupine, Vosk requires no API key and runs entirely offline.
+    Accuracy is lower than dedicated wake word engines for short phrases,
+    but it is suitable for development, testing, and privacy-sensitive deployments.
+
+    Requires: vosk library and a Vosk model directory
+    Install: pip install vosk
+    Models: https://alphacephei.com/vosk/models (download a small model, e.g. vosk-model-small-en-us)
+
+    Usage:
+        config = WakeWordConfig(
+            keywords=["hey champi", "stop"],
+            model_path="/path/to/vosk-model-small-en-us",
+        )
+        engine = VoskWakeWord(config)
+        await engine.initialize()
+        detected, keyword = await engine.process_audio(audio_chunk)
+    """
+
+    def __init__(self, config: WakeWordConfig) -> None:
+        if not VOSK_AVAILABLE:
+            raise ImportError(
+                "Vosk is not installed. Install with: pip install vosk\n"
+                "Download a model from: https://alphacephei.com/vosk/models"
+            )
+        super().__init__(config)
+        self._model: Model | None = None
+        self._recognizer: KaldiRecognizer | None = None
+
+    async def initialize(self) -> None:
+        """Load the Vosk model and build a grammar-constrained recognizer."""
+        if self._initialized:
+            return
+
+        if not self.config.model_path:
+            raise ValueError(
+                "VoskWakeWord requires model_path in WakeWordConfig. "
+                "Download a model from https://alphacephei.com/vosk/models and set model_path."
+            )
+
+        logger.info(f"Loading Vosk model from: {self.config.model_path}")
+
+        try:
+            self._model = Model(self.config.model_path)
+
+            # Build a grammar that only accepts the configured keywords plus silence.
+            # This dramatically reduces false positives compared to full ASR.
+            grammar = json.dumps(self.config.keywords + ["[unk]"])
+            self._recognizer = KaldiRecognizer(
+                self._model, self.config.sample_rate, grammar
+            )
+            self._recognizer.SetWords(False)
+
+            self._initialized = True
+            logger.info(
+                f"Vosk wake word engine initialized with keywords: {self.config.keywords}"
+            )
+        except Exception as exc:
+            logger.error(f"Failed to initialize Vosk: {exc}")
+            raise RuntimeError(f"Vosk initialization failed: {exc}") from exc
+
+    async def process_audio(self, audio_chunk: np.ndarray) -> tuple[bool, str | None]:
+        """
+        Feed a chunk of audio to the recognizer and check for keyword matches.
+
+        Args:
+            audio_chunk: Audio data as int16 or float32 numpy array.
+                         Will be converted to int16 PCM if needed.
+
+        Returns:
+            (detected, keyword) — keyword is the matched phrase or None.
+        """
+        if not self._initialized or self._recognizer is None:
+            raise RuntimeError("VoskWakeWord not initialized. Call initialize() first.")
+
+        pcm = self._to_int16_bytes(audio_chunk)
+
+        if self._recognizer.AcceptWaveform(pcm):
+            result = json.loads(self._recognizer.Result())
+            text = result.get("text", "").strip().lower()
+        else:
+            partial = json.loads(self._recognizer.PartialResult())
+            text = partial.get("partial", "").strip().lower()
+
+        if not text or text == "[unk]":
+            return False, None
+
+        for keyword in self.config.keywords:
+            if keyword.lower() in text:
+                logger.debug(f"Wake word detected: '{keyword}' (text='{text}')")
+                return True, keyword
+
+        return False, None
+
+    async def shutdown(self) -> None:
+        """Release Vosk model resources."""
+        self._recognizer = None
+        self._model = None
+        self._initialized = False
+        logger.debug("Vosk wake word engine shut down")
+
+    @property
+    def is_initialized(self) -> bool:
+        return self._initialized and self._recognizer is not None
+
+    @staticmethod
+    def _to_int16_bytes(audio: np.ndarray) -> bytes:
+        """Convert numpy array to int16 PCM bytes as Vosk expects."""
+        if audio.dtype == np.float32 or audio.dtype == np.float64:
+            audio = (audio * 32767).clip(-32768, 32767).astype(np.int16)
+        elif audio.dtype != np.int16:
+            audio = audio.astype(np.int16)
+        return audio.tobytes()

--- a/tests/test_vosk_wakeword.py
+++ b/tests/test_vosk_wakeword.py
@@ -1,0 +1,214 @@
+"""Tests for VoskWakeWord engine."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from champi_stt.assistant.wakeword.base import WakeWordConfig
+
+
+def _make_config(**kwargs):
+    defaults = {
+        "keywords": ["hey champi", "stop"],
+        "model_path": "/fake/model/path",
+        "sample_rate": 16000,
+    }
+    defaults.update(kwargs)
+    return WakeWordConfig(**defaults)
+
+
+@pytest.fixture
+def mock_vosk():
+    mock_model = MagicMock()
+    mock_recognizer = MagicMock()
+
+    with patch("champi_stt.assistant.wakeword.vosk.VOSK_AVAILABLE", True):
+        with patch("champi_stt.assistant.wakeword.vosk.Model", return_value=mock_model):
+            with patch(
+                "champi_stt.assistant.wakeword.vosk.KaldiRecognizer",
+                return_value=mock_recognizer,
+            ):
+                yield mock_model, mock_recognizer
+
+
+class TestVoskWakeWordInit:
+    def test_raises_without_vosk(self):
+        with patch("champi_stt.assistant.wakeword.vosk.VOSK_AVAILABLE", False):
+            from champi_stt.assistant.wakeword.vosk import VoskWakeWord
+            with pytest.raises(ImportError, match="vosk"):
+                VoskWakeWord(_make_config())
+
+    def test_not_initialized_by_default(self, mock_vosk):
+        from champi_stt.assistant.wakeword.vosk import VoskWakeWord
+        engine = VoskWakeWord(_make_config())
+        assert not engine.is_initialized
+
+    @pytest.mark.asyncio
+    async def test_initialize_success(self, mock_vosk):
+        from champi_stt.assistant.wakeword.vosk import VoskWakeWord
+        engine = VoskWakeWord(_make_config())
+        await engine.initialize()
+        assert engine.is_initialized
+
+    @pytest.mark.asyncio
+    async def test_initialize_requires_model_path(self, mock_vosk):
+        from champi_stt.assistant.wakeword.vosk import VoskWakeWord
+        config = _make_config(model_path=None)
+        engine = VoskWakeWord(config)
+        with pytest.raises(ValueError, match="model_path"):
+            await engine.initialize()
+
+    @pytest.mark.asyncio
+    async def test_initialize_idempotent(self, mock_vosk):
+        _, mock_recognizer = mock_vosk
+        from champi_stt.assistant.wakeword.vosk import VoskWakeWord
+        engine = VoskWakeWord(_make_config())
+        await engine.initialize()
+        await engine.initialize()
+        # Model should only be created once
+        assert engine.is_initialized
+
+    @pytest.mark.asyncio
+    async def test_initialize_failure_raises(self):
+        with patch("champi_stt.assistant.wakeword.vosk.VOSK_AVAILABLE", True):
+            with patch(
+                "champi_stt.assistant.wakeword.vosk.Model",
+                side_effect=Exception("model not found"),
+            ):
+                from champi_stt.assistant.wakeword.vosk import VoskWakeWord
+                engine = VoskWakeWord(_make_config())
+                with pytest.raises(RuntimeError, match="Vosk initialization failed"):
+                    await engine.initialize()
+
+
+class TestVoskProcessAudio:
+    @pytest.mark.asyncio
+    async def test_detect_keyword_in_final_result(self, mock_vosk):
+        _, mock_recognizer = mock_vosk
+        mock_recognizer.AcceptWaveform.return_value = True
+        mock_recognizer.Result.return_value = json.dumps({"text": "hey champi"})
+
+        from champi_stt.assistant.wakeword.vosk import VoskWakeWord
+        engine = VoskWakeWord(_make_config())
+        await engine.initialize()
+
+        audio = np.zeros(512, dtype=np.int16)
+        detected, keyword = await engine.process_audio(audio)
+        assert detected is True
+        assert keyword == "hey champi"
+
+    @pytest.mark.asyncio
+    async def test_detect_keyword_in_partial_result(self, mock_vosk):
+        _, mock_recognizer = mock_vosk
+        mock_recognizer.AcceptWaveform.return_value = False
+        mock_recognizer.PartialResult.return_value = json.dumps({"partial": "stop now"})
+
+        from champi_stt.assistant.wakeword.vosk import VoskWakeWord
+        engine = VoskWakeWord(_make_config())
+        await engine.initialize()
+
+        audio = np.zeros(512, dtype=np.int16)
+        detected, keyword = await engine.process_audio(audio)
+        assert detected is True
+        assert keyword == "stop"
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_false(self, mock_vosk):
+        _, mock_recognizer = mock_vosk
+        mock_recognizer.AcceptWaveform.return_value = True
+        mock_recognizer.Result.return_value = json.dumps({"text": "random other words"})
+
+        from champi_stt.assistant.wakeword.vosk import VoskWakeWord
+        engine = VoskWakeWord(_make_config())
+        await engine.initialize()
+
+        audio = np.zeros(512, dtype=np.int16)
+        detected, keyword = await engine.process_audio(audio)
+        assert detected is False
+        assert keyword is None
+
+    @pytest.mark.asyncio
+    async def test_empty_text_returns_false(self, mock_vosk):
+        _, mock_recognizer = mock_vosk
+        mock_recognizer.AcceptWaveform.return_value = True
+        mock_recognizer.Result.return_value = json.dumps({"text": ""})
+
+        from champi_stt.assistant.wakeword.vosk import VoskWakeWord
+        engine = VoskWakeWord(_make_config())
+        await engine.initialize()
+
+        audio = np.zeros(512, dtype=np.int16)
+        detected, _ = await engine.process_audio(audio)
+        assert detected is False
+
+    @pytest.mark.asyncio
+    async def test_unk_returns_false(self, mock_vosk):
+        _, mock_recognizer = mock_vosk
+        mock_recognizer.AcceptWaveform.return_value = True
+        mock_recognizer.Result.return_value = json.dumps({"text": "[unk]"})
+
+        from champi_stt.assistant.wakeword.vosk import VoskWakeWord
+        engine = VoskWakeWord(_make_config())
+        await engine.initialize()
+
+        audio = np.zeros(512, dtype=np.int16)
+        detected, _ = await engine.process_audio(audio)
+        assert detected is False
+
+    @pytest.mark.asyncio
+    async def test_not_initialized_raises(self, mock_vosk):
+        from champi_stt.assistant.wakeword.vosk import VoskWakeWord
+        engine = VoskWakeWord(_make_config())
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await engine.process_audio(np.zeros(512, dtype=np.int16))
+
+    @pytest.mark.asyncio
+    async def test_float32_audio_accepted(self, mock_vosk):
+        _, mock_recognizer = mock_vosk
+        mock_recognizer.AcceptWaveform.return_value = True
+        mock_recognizer.Result.return_value = json.dumps({"text": "hey champi"})
+
+        from champi_stt.assistant.wakeword.vosk import VoskWakeWord
+        engine = VoskWakeWord(_make_config())
+        await engine.initialize()
+
+        audio = np.zeros(512, dtype=np.float32)
+        detected, keyword = await engine.process_audio(audio)
+        assert detected is True
+
+
+class TestVoskShutdown:
+    @pytest.mark.asyncio
+    async def test_shutdown_clears_state(self, mock_vosk):
+        from champi_stt.assistant.wakeword.vosk import VoskWakeWord
+        engine = VoskWakeWord(_make_config())
+        await engine.initialize()
+        assert engine.is_initialized
+        await engine.shutdown()
+        assert not engine.is_initialized
+        assert engine._recognizer is None
+        assert engine._model is None
+
+
+class TestToInt16Bytes:
+    def test_int16_passthrough(self):
+        from champi_stt.assistant.wakeword.vosk import VoskWakeWord
+        audio = np.array([100, -100, 0], dtype=np.int16)
+        result = VoskWakeWord._to_int16_bytes(audio)
+        assert isinstance(result, bytes)
+        assert len(result) == 6  # 3 samples * 2 bytes
+
+    def test_float32_conversion(self):
+        from champi_stt.assistant.wakeword.vosk import VoskWakeWord
+        audio = np.array([0.5, -0.5], dtype=np.float32)
+        result = VoskWakeWord._to_int16_bytes(audio)
+        assert isinstance(result, bytes)
+        assert len(result) == 4  # 2 samples * 2 bytes
+
+    def test_other_dtype_conversion(self):
+        from champi_stt.assistant.wakeword.vosk import VoskWakeWord
+        audio = np.array([100, 200], dtype=np.int32)
+        result = VoskWakeWord._to_int16_bytes(audio)
+        assert isinstance(result, bytes)


### PR DESCRIPTION
## Summary

- Implements `VoskWakeWord` in `src/champi_stt/assistant/wakeword/vosk.py`
- Conforms to the `BaseWakeWordEngine` interface (`initialize`, `process_audio`, `shutdown`, `is_initialized`)
- Uses grammar-constrained `KaldiRecognizer` to limit recognition to configured keywords, reducing false positives
- No API key or internet connection required — suitable for offline and privacy-sensitive deployments
- Adds `vosk` optional extra to `pyproject.toml`
- Exports `VoskWakeWord` from the `wakeword` package `__init__.py`

## Test plan
- [x] `uv run pytest tests/test_vosk_wakeword.py` — 17 passed
- [x] Full suite — 209 passed, 111 skipped, 0 failures
- [x] Tests mock the vosk library — run without vosk installed

Closes #16