### PR TITLE
feat: add systemd user service installer

### DIFF
--- a/src/champi_stt/assistant/service/systemd/__init__.py
+++ b/src/champi_stt/assistant/service/systemd/__init__.py
@@ -1,0 +1,1 @@
+"""Systemd service installation utilities."""

--- a/src/champi_stt/assistant/service/systemd/installer.py
+++ b/src/champi_stt/assistant/service/systemd/installer.py
@@ -1,0 +1,165 @@
+"""
+Systemd user service installer for champi-stt.
+
+Installs champi-stt as a ~/.config/systemd/user/ service so it starts
+automatically on login without requiring root privileges.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from string import Template
+
+from loguru import logger
+
+_SERVICE_TEMPLATE = Template("""\
+[Unit]
+Description=Champi STT Voice Assistant
+After=network.target sound.target
+Wants=network.target
+
+[Service]
+Type=simple
+ExecStart=$exec_path start --config $config_path
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+Environment=PYTHONUNBUFFERED=1
+
+[Install]
+WantedBy=default.target
+""")
+
+_SERVICE_NAME = "champi-stt.service"
+
+
+def _systemd_user_dir() -> Path:
+    return Path(os.path.expanduser("~/.config/systemd/user"))
+
+
+def _champi_exec() -> str:
+    """Return the absolute path to the champi-stt executable."""
+    exe = shutil.which("champi-stt")
+    if exe:
+        return exe
+    # Fall back to the current Python environment's bin dir
+    return str(Path(sys.executable).parent / "champi-stt")
+
+
+def _default_config_path() -> str:
+    return str(Path(os.path.expanduser("~/.config/champi-stt/assistant_config.yaml")))
+
+
+def install(
+    config: str | None = None,
+    user: str | None = None,
+    enable: bool = True,
+    start: bool = True,
+) -> Path:
+    """
+    Install champi-stt as a systemd user service.
+
+    Args:
+        config: Path to assistant_config.yaml (defaults to ~/.config/champi-stt/assistant_config.yaml)
+        user:   Unused — user services always install to the current user's systemd directory.
+        enable: Run `systemctl --user enable` after installing.
+        start:  Run `systemctl --user start` after enabling.
+
+    Returns:
+        Path to the installed .service file.
+
+    Raises:
+        RuntimeError: If systemctl is not available on this system.
+    """
+    if not shutil.which("systemctl"):
+        raise RuntimeError(
+            "systemctl not found. Systemd service installation requires a Linux system with systemd."
+        )
+
+    config_path = config or _default_config_path()
+    exec_path = _champi_exec()
+
+    service_content = _SERVICE_TEMPLATE.substitute(
+        exec_path=exec_path,
+        config_path=config_path,
+    )
+
+    service_dir = _systemd_user_dir()
+    service_dir.mkdir(parents=True, exist_ok=True)
+    service_file = service_dir / _SERVICE_NAME
+
+    service_file.write_text(service_content)
+    logger.info(f"Service file written to: {service_file}")
+
+    # Reload systemd daemon to pick up new unit file
+    subprocess.run(["systemctl", "--user", "daemon-reload"], check=True)
+    logger.info("systemd user daemon reloaded")
+
+    if enable:
+        subprocess.run(["systemctl", "--user", "enable", _SERVICE_NAME], check=True)
+        logger.info(f"Service enabled: {_SERVICE_NAME}")
+
+    if start:
+        subprocess.run(["systemctl", "--user", "start", _SERVICE_NAME], check=True)
+        logger.info(f"Service started: {_SERVICE_NAME}")
+
+    return service_file
+
+
+def uninstall(stop: bool = True) -> None:
+    """
+    Remove the champi-stt systemd user service.
+
+    Args:
+        stop: Stop the service before removing it.
+    """
+    if shutil.which("systemctl"):
+        if stop:
+            subprocess.run(
+                ["systemctl", "--user", "stop", _SERVICE_NAME],
+                check=False,  # don't fail if not running
+            )
+        subprocess.run(
+            ["systemctl", "--user", "disable", _SERVICE_NAME],
+            check=False,
+        )
+        subprocess.run(["systemctl", "--user", "daemon-reload"], check=False)
+
+    service_file = _systemd_user_dir() / _SERVICE_NAME
+    if service_file.exists():
+        service_file.unlink()
+        logger.info(f"Removed service file: {service_file}")
+    else:
+        logger.warning(f"Service file not found: {service_file}")
+
+
+def status() -> str:
+    """Return the output of `systemctl --user status champi-stt`."""
+    if not shutil.which("systemctl"):
+        return "systemctl not available"
+    result = subprocess.run(
+        ["systemctl", "--user", "status", _SERVICE_NAME],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout + result.stderr
+
+
+def is_installed() -> bool:
+    """Return True if the service file is present."""
+    return (_systemd_user_dir() / _SERVICE_NAME).exists()
+
+
+def is_active() -> bool:
+    """Return True if the service is currently running."""
+    if not shutil.which("systemctl"):
+        return False
+    result = subprocess.run(
+        ["systemctl", "--user", "is-active", _SERVICE_NAME],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() == "active"

--- a/src/champi_stt/cli.py
+++ b/src/champi_stt/cli.py
@@ -505,5 +505,56 @@ def test_ui(prefix):
         click.echo(f"❌ Error: {e}")
 
 
+@cli.group()
+def service():
+    """Manage the champi-stt system service."""
+
+
+@service.command("install")
+@click.option("--config", default=None, help="Path to assistant_config.yaml")
+@click.option("--type", "service_type", default="systemd",
+              type=click.Choice(["systemd"]), show_default=True,
+              help="Service manager type")
+@click.option("--no-enable", is_flag=True, default=False, help="Skip systemctl enable")
+@click.option("--no-start", is_flag=True, default=False, help="Skip systemctl start")
+def service_install(config, service_type, no_enable, no_start):
+    """Install champi-stt as a system service."""
+    if service_type == "systemd":
+        from champi_stt.assistant.service.systemd.installer import install
+        try:
+            path = install(config=config, enable=not no_enable, start=not no_start)
+            click.echo(f"Service installed: {path}")
+            if not no_start:
+                click.echo("Service started. Check status with: champi-stt service status")
+        except Exception as e:
+            click.echo(f"Error: {e}", err=True)
+            raise SystemExit(1)
+
+
+@service.command("uninstall")
+@click.option("--type", "service_type", default="systemd",
+              type=click.Choice(["systemd"]), show_default=True)
+def service_uninstall(service_type):
+    """Remove the champi-stt system service."""
+    if service_type == "systemd":
+        from champi_stt.assistant.service.systemd.installer import uninstall
+        try:
+            uninstall()
+            click.echo("Service uninstalled.")
+        except Exception as e:
+            click.echo(f"Error: {e}", err=True)
+            raise SystemExit(1)
+
+
+@service.command("status")
+@click.option("--type", "service_type", default="systemd",
+              type=click.Choice(["systemd"]), show_default=True)
+def service_status(service_type):
+    """Show the status of the champi-stt service."""
+    if service_type == "systemd":
+        from champi_stt.assistant.service.systemd.installer import status
+        click.echo(status())
+
+
 if __name__ == "__main__":
     cli()

--- a/tests/test_systemd_installer.py
+++ b/tests/test_systemd_installer.py
@@ -1,0 +1,151 @@
+"""Tests for systemd service installer."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from champi_stt.assistant.service.systemd.installer import (
+    _SERVICE_NAME,
+    _champi_exec,
+    _default_config_path,
+    _systemd_user_dir,
+    install,
+    is_active,
+    is_installed,
+    status,
+    uninstall,
+)
+
+
+@pytest.fixture
+def fake_systemd(tmp_path):
+    """Patch systemctl availability and service dir to use tmp_path."""
+    service_dir = tmp_path / ".config" / "systemd" / "user"
+    service_dir.mkdir(parents=True)
+
+    with patch("champi_stt.assistant.service.systemd.installer.shutil.which", return_value="/bin/systemctl"):
+        with patch("champi_stt.assistant.service.systemd.installer._systemd_user_dir", return_value=service_dir):
+            with patch("champi_stt.assistant.service.systemd.installer.subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout="active\n", stderr="")
+                yield service_dir, mock_run
+
+
+class TestInstall:
+    def test_creates_service_file(self, fake_systemd):
+        service_dir, _ = fake_systemd
+        path = install(config="/fake/config.yaml", enable=False, start=False)
+        assert (service_dir / _SERVICE_NAME).exists()
+        assert path == service_dir / _SERVICE_NAME
+
+    def test_service_file_content(self, fake_systemd):
+        service_dir, _ = fake_systemd
+        install(config="/fake/config.yaml", enable=False, start=False)
+        content = (service_dir / _SERVICE_NAME).read_text()
+        assert "/fake/config.yaml" in content
+        assert "[Unit]" in content
+        assert "[Service]" in content
+        assert "[Install]" in content
+        assert "ExecStart=" in content
+
+    def test_daemon_reload_called(self, fake_systemd):
+        _, mock_run = fake_systemd
+        install(config="/cfg.yaml", enable=False, start=False)
+        calls = [str(c) for c in mock_run.call_args_list]
+        assert any("daemon-reload" in c for c in calls)
+
+    def test_enable_called_when_requested(self, fake_systemd):
+        _, mock_run = fake_systemd
+        install(config="/cfg.yaml", enable=True, start=False)
+        calls = [str(c) for c in mock_run.call_args_list]
+        assert any("enable" in c for c in calls)
+
+    def test_start_called_when_requested(self, fake_systemd):
+        _, mock_run = fake_systemd
+        install(config="/cfg.yaml", enable=False, start=True)
+        calls = [str(c) for c in mock_run.call_args_list]
+        assert any("start" in c for c in calls)
+
+    def test_no_enable_no_start(self, fake_systemd):
+        _, mock_run = fake_systemd
+        install(config="/cfg.yaml", enable=False, start=False)
+        calls = [str(c) for c in mock_run.call_args_list]
+        assert not any("enable" in c for c in calls)
+        assert not any('"start"' in c for c in calls)
+
+    def test_raises_without_systemctl(self, tmp_path):
+        with patch("champi_stt.assistant.service.systemd.installer.shutil.which", return_value=None):
+            with pytest.raises(RuntimeError, match="systemctl not found"):
+                install()
+
+
+class TestUninstall:
+    def test_removes_service_file(self, fake_systemd):
+        service_dir, _ = fake_systemd
+        service_file = service_dir / _SERVICE_NAME
+        service_file.write_text("[Unit]\n")
+        uninstall()
+        assert not service_file.exists()
+
+    def test_stop_and_disable_called(self, fake_systemd):
+        service_dir, mock_run = fake_systemd
+        (service_dir / _SERVICE_NAME).write_text("[Unit]\n")
+        uninstall(stop=True)
+        calls = [str(c) for c in mock_run.call_args_list]
+        assert any("stop" in c for c in calls)
+        assert any("disable" in c for c in calls)
+
+    def test_missing_file_ok(self, fake_systemd):
+        # Should not raise even if file doesn't exist
+        uninstall()
+
+
+class TestStatus:
+    def test_returns_output(self, fake_systemd):
+        _, mock_run = fake_systemd
+        mock_run.return_value = MagicMock(stdout="active running\n", stderr="")
+        result = status()
+        assert isinstance(result, str)
+
+    def test_no_systemctl(self):
+        with patch("champi_stt.assistant.service.systemd.installer.shutil.which", return_value=None):
+            result = status()
+            assert "not available" in result
+
+
+class TestIsInstalled:
+    def test_true_when_file_exists(self, fake_systemd):
+        service_dir, _ = fake_systemd
+        (service_dir / _SERVICE_NAME).write_text("[Unit]\n")
+        assert is_installed() is True
+
+    def test_false_when_missing(self, fake_systemd):
+        assert is_installed() is False
+
+
+class TestIsActive:
+    def test_active(self, fake_systemd):
+        _, mock_run = fake_systemd
+        mock_run.return_value = MagicMock(stdout="active\n", stderr="", returncode=0)
+        assert is_active() is True
+
+    def test_inactive(self, fake_systemd):
+        _, mock_run = fake_systemd
+        mock_run.return_value = MagicMock(stdout="inactive\n", stderr="", returncode=3)
+        assert is_active() is False
+
+    def test_no_systemctl(self):
+        with patch("champi_stt.assistant.service.systemd.installer.shutil.which", return_value=None):
+            assert is_active() is False
+
+
+class TestHelpers:
+    def test_default_config_path_in_home(self):
+        path = _default_config_path()
+        assert "champi-stt" in path
+        assert path.endswith(".yaml")
+
+    def test_champi_exec_returns_string(self):
+        result = _champi_exec()
+        assert isinstance(result, str)
+        assert len(result) > 0


### PR DESCRIPTION
## Summary

- Adds `src/champi_stt/assistant/service/systemd/installer.py` with `install`, `uninstall`, `status`, `is_installed`, `is_active` functions
- Service installs to `~/.config/systemd/user/champi-stt.service` (no root required)
- Adds `champi-stt service install --type systemd` CLI subcommand with `--config`, `--no-enable`, `--no-start` flags
- Adds `champi-stt service uninstall` and `champi-stt service status` subcommands

## Test plan
- [x] `uv run pytest tests/test_systemd_installer.py` — 19 passed
- [x] Full suite — 0 failures

Closes #17