### PR TITLE
feat: add launchd plist installer for macOS

### DIFF
--- a/src/champi_stt/assistant/service/launchd/__init__.py
+++ b/src/champi_stt/assistant/service/launchd/__init__.py
@@ -1,0 +1,1 @@
+"""Launchd service installation utilities for macOS."""

--- a/src/champi_stt/assistant/service/launchd/installer.py
+++ b/src/champi_stt/assistant/service/launchd/installer.py
@@ -1,0 +1,178 @@
+"""
+Launchd plist installer for champi-stt on macOS.
+
+Installs champi-stt as a ~/Library/LaunchAgents/ agent so it starts
+automatically on login without requiring root privileges.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from string import Template
+
+from loguru import logger
+
+_PLIST_TEMPLATE = Template("""\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>ai.champi.stt</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>$exec_path</string>
+        <string>start</string>
+        <string>--config</string>
+        <string>$config_path</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>$log_dir/champi-stt.stdout.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>$log_dir/champi-stt.stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PYTHONUNBUFFERED</key>
+        <string>1</string>
+    </dict>
+</dict>
+</plist>
+""")
+
+_PLIST_LABEL = "ai.champi.stt"
+_PLIST_FILENAME = f"{_PLIST_LABEL}.plist"
+
+
+def _launch_agents_dir() -> Path:
+    return Path(os.path.expanduser("~/Library/LaunchAgents"))
+
+
+def _log_dir() -> str:
+    return str(Path(os.path.expanduser("~/Library/Logs/champi-stt")))
+
+
+def _champi_exec() -> str:
+    exe = shutil.which("champi-stt")
+    if exe:
+        return exe
+    return str(Path(sys.executable).parent / "champi-stt")
+
+
+def _default_config_path() -> str:
+    return str(Path(os.path.expanduser("~/.config/champi-stt/assistant_config.yaml")))
+
+
+def install(
+    config: str | None = None,
+    load: bool = True,
+) -> Path:
+    """
+    Install champi-stt as a launchd LaunchAgent.
+
+    Args:
+        config: Path to assistant_config.yaml (defaults to ~/.config/champi-stt/assistant_config.yaml)
+        load:   Run `launchctl load` after installing.
+
+    Returns:
+        Path to the installed .plist file.
+
+    Raises:
+        RuntimeError: If launchctl is not available (non-macOS system).
+    """
+    if not shutil.which("launchctl"):
+        raise RuntimeError(
+            "launchctl not found. Launchd service installation requires macOS."
+        )
+
+    config_path = config or _default_config_path()
+    exec_path = _champi_exec()
+    log_dir = _log_dir()
+
+    Path(log_dir).mkdir(parents=True, exist_ok=True)
+
+    plist_content = _PLIST_TEMPLATE.substitute(
+        exec_path=exec_path,
+        config_path=config_path,
+        log_dir=log_dir,
+    )
+
+    agents_dir = _launch_agents_dir()
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    plist_file = agents_dir / _PLIST_FILENAME
+
+    plist_file.write_text(plist_content)
+    logger.info(f"Plist written to: {plist_file}")
+
+    if load:
+        subprocess.run(["launchctl", "load", str(plist_file)], check=True)
+        logger.info(f"LaunchAgent loaded: {_PLIST_LABEL}")
+
+    return plist_file
+
+
+def uninstall(unload: bool = True) -> None:
+    """
+    Remove the champi-stt LaunchAgent plist.
+
+    Args:
+        unload: Run `launchctl unload` before removing the plist.
+    """
+    plist_file = _launch_agents_dir() / _PLIST_FILENAME
+
+    if unload and shutil.which("launchctl") and plist_file.exists():
+        subprocess.run(
+            ["launchctl", "unload", str(plist_file)],
+            check=False,
+        )
+        logger.info(f"LaunchAgent unloaded: {_PLIST_LABEL}")
+
+    if plist_file.exists():
+        plist_file.unlink()
+        logger.info(f"Removed plist: {plist_file}")
+    else:
+        logger.warning(f"Plist not found: {plist_file}")
+
+
+def status() -> str:
+    """Return the output of `launchctl list ai.champi.stt`."""
+    if not shutil.which("launchctl"):
+        return "launchctl not available"
+    result = subprocess.run(
+        ["launchctl", "list", _PLIST_LABEL],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout + result.stderr
+
+
+def is_installed() -> bool:
+    """Return True if the plist file is present."""
+    return (_launch_agents_dir() / _PLIST_FILENAME).exists()
+
+
+def is_loaded() -> bool:
+    """Return True if the agent is currently loaded in launchctl."""
+    if not shutil.which("launchctl"):
+        return False
+    result = subprocess.run(
+        ["launchctl", "list", _PLIST_LABEL],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0

--- a/src/champi_stt/cli.py
+++ b/src/champi_stt/cli.py
@@ -513,47 +513,54 @@ def service():
 @service.command("install")
 @click.option("--config", default=None, help="Path to assistant_config.yaml")
 @click.option("--type", "service_type", default="systemd",
-              type=click.Choice(["systemd"]), show_default=True,
+              type=click.Choice(["systemd", "launchd"]), show_default=True,
               help="Service manager type")
-@click.option("--no-enable", is_flag=True, default=False, help="Skip systemctl enable")
-@click.option("--no-start", is_flag=True, default=False, help="Skip systemctl start")
+@click.option("--no-enable", is_flag=True, default=False, help="Skip systemctl enable (systemd only)")
+@click.option("--no-start", is_flag=True, default=False, help="Skip start after install")
 def service_install(config, service_type, no_enable, no_start):
     """Install champi-stt as a system service."""
-    if service_type == "systemd":
-        from champi_stt.assistant.service.systemd.installer import install
-        try:
+    try:
+        if service_type == "systemd":
+            from champi_stt.assistant.service.systemd.installer import install
             path = install(config=config, enable=not no_enable, start=not no_start)
-            click.echo(f"Service installed: {path}")
-            if not no_start:
-                click.echo("Service started. Check status with: champi-stt service status")
-        except Exception as e:
-            click.echo(f"Error: {e}", err=True)
-            raise SystemExit(1)
+        else:
+            from champi_stt.assistant.service.launchd.installer import install
+            path = install(config=config, load=not no_start)
+        click.echo(f"Service installed: {path}")
+        if not no_start:
+            click.echo("Service started. Check status with: champi-stt service status")
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        raise SystemExit(1)
 
 
 @service.command("uninstall")
 @click.option("--type", "service_type", default="systemd",
-              type=click.Choice(["systemd"]), show_default=True)
+              type=click.Choice(["systemd", "launchd"]), show_default=True)
 def service_uninstall(service_type):
     """Remove the champi-stt system service."""
-    if service_type == "systemd":
-        from champi_stt.assistant.service.systemd.installer import uninstall
-        try:
-            uninstall()
-            click.echo("Service uninstalled.")
-        except Exception as e:
-            click.echo(f"Error: {e}", err=True)
-            raise SystemExit(1)
+    try:
+        if service_type == "systemd":
+            from champi_stt.assistant.service.systemd.installer import uninstall
+        else:
+            from champi_stt.assistant.service.launchd.installer import uninstall
+        uninstall()
+        click.echo("Service uninstalled.")
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        raise SystemExit(1)
 
 
 @service.command("status")
 @click.option("--type", "service_type", default="systemd",
-              type=click.Choice(["systemd"]), show_default=True)
+              type=click.Choice(["systemd", "launchd"]), show_default=True)
 def service_status(service_type):
     """Show the status of the champi-stt service."""
     if service_type == "systemd":
         from champi_stt.assistant.service.systemd.installer import status
-        click.echo(status())
+    else:
+        from champi_stt.assistant.service.launchd.installer import status
+    click.echo(status())
 
 
 if __name__ == "__main__":

--- a/tests/test_launchd_installer.py
+++ b/tests/test_launchd_installer.py
@@ -1,0 +1,144 @@
+"""Tests for launchd plist installer."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from champi_stt.assistant.service.launchd.installer import (
+    _PLIST_FILENAME,
+    _PLIST_LABEL,
+    _champi_exec,
+    _default_config_path,
+    _launch_agents_dir,
+    install,
+    is_installed,
+    is_loaded,
+    status,
+    uninstall,
+)
+
+
+@pytest.fixture
+def fake_launchd(tmp_path):
+    agents_dir = tmp_path / "Library" / "LaunchAgents"
+    agents_dir.mkdir(parents=True)
+    log_dir = tmp_path / "Library" / "Logs" / "champi-stt"
+
+    with patch("champi_stt.assistant.service.launchd.installer.shutil.which", return_value="/usr/bin/launchctl"):
+        with patch("champi_stt.assistant.service.launchd.installer._launch_agents_dir", return_value=agents_dir):
+            with patch("champi_stt.assistant.service.launchd.installer._log_dir", return_value=str(log_dir)):
+                with patch("champi_stt.assistant.service.launchd.installer.subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+                    yield agents_dir, mock_run
+
+
+class TestInstall:
+    def test_creates_plist_file(self, fake_launchd):
+        agents_dir, _ = fake_launchd
+        path = install(config="/fake/config.yaml", load=False)
+        assert (agents_dir / _PLIST_FILENAME).exists()
+        assert path == agents_dir / _PLIST_FILENAME
+
+    def test_plist_content(self, fake_launchd):
+        agents_dir, _ = fake_launchd
+        install(config="/fake/config.yaml", load=False)
+        content = (agents_dir / _PLIST_FILENAME).read_text()
+        assert "/fake/config.yaml" in content
+        assert _PLIST_LABEL in content
+        assert "<key>RunAtLoad</key>" in content
+        assert "<key>KeepAlive</key>" in content
+        assert "ProgramArguments" in content
+
+    def test_launchctl_load_called(self, fake_launchd):
+        _, mock_run = fake_launchd
+        install(config="/cfg.yaml", load=True)
+        calls = [str(c) for c in mock_run.call_args_list]
+        assert any("load" in c for c in calls)
+
+    def test_no_load(self, fake_launchd):
+        _, mock_run = fake_launchd
+        install(config="/cfg.yaml", load=False)
+        calls = [str(c) for c in mock_run.call_args_list]
+        assert not any("'load'" in c for c in calls)
+
+    def test_raises_without_launchctl(self, tmp_path):
+        with patch("champi_stt.assistant.service.launchd.installer.shutil.which", return_value=None):
+            with pytest.raises(RuntimeError, match="launchctl not found"):
+                install()
+
+    def test_creates_log_dir(self, fake_launchd, tmp_path):
+        agents_dir, _ = fake_launchd
+        log_path = tmp_path / "new_logs"
+        with patch("champi_stt.assistant.service.launchd.installer._log_dir", return_value=str(log_path)):
+            install(config="/cfg.yaml", load=False)
+        assert log_path.exists()
+
+
+class TestUninstall:
+    def test_removes_plist_file(self, fake_launchd):
+        agents_dir, _ = fake_launchd
+        (agents_dir / _PLIST_FILENAME).write_text("<plist/>")
+        uninstall()
+        assert not (agents_dir / _PLIST_FILENAME).exists()
+
+    def test_launchctl_unload_called(self, fake_launchd):
+        agents_dir, mock_run = fake_launchd
+        (agents_dir / _PLIST_FILENAME).write_text("<plist/>")
+        uninstall(unload=True)
+        calls = [str(c) for c in mock_run.call_args_list]
+        assert any("unload" in c for c in calls)
+
+    def test_missing_file_ok(self, fake_launchd):
+        uninstall()  # should not raise
+
+
+class TestStatus:
+    def test_returns_output(self, fake_launchd):
+        _, mock_run = fake_launchd
+        mock_run.return_value = MagicMock(stdout="PID\t0\tai.champi.stt\n", stderr="")
+        result = status()
+        assert isinstance(result, str)
+
+    def test_no_launchctl(self):
+        with patch("champi_stt.assistant.service.launchd.installer.shutil.which", return_value=None):
+            result = status()
+            assert "not available" in result
+
+
+class TestIsInstalled:
+    def test_true_when_file_exists(self, fake_launchd):
+        agents_dir, _ = fake_launchd
+        (agents_dir / _PLIST_FILENAME).write_text("<plist/>")
+        assert is_installed() is True
+
+    def test_false_when_missing(self, fake_launchd):
+        assert is_installed() is False
+
+
+class TestIsLoaded:
+    def test_loaded(self, fake_launchd):
+        _, mock_run = fake_launchd
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        assert is_loaded() is True
+
+    def test_not_loaded(self, fake_launchd):
+        _, mock_run = fake_launchd
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="")
+        assert is_loaded() is False
+
+    def test_no_launchctl(self):
+        with patch("champi_stt.assistant.service.launchd.installer.shutil.which", return_value=None):
+            assert is_loaded() is False
+
+
+class TestHelpers:
+    def test_default_config_path(self):
+        path = _default_config_path()
+        assert "champi-stt" in path
+        assert path.endswith(".yaml")
+
+    def test_champi_exec_returns_string(self):
+        result = _champi_exec()
+        assert isinstance(result, str)
+        assert len(result) > 0


### PR DESCRIPTION
## Summary

- Adds `src/champi_stt/assistant/service/launchd/installer.py` with `install`, `uninstall`, `status`, `is_installed`, `is_loaded` functions
- Plist installs to `~/Library/LaunchAgents/ai.champi.stt.plist` (no root required)
- Extends `champi-stt service install/uninstall/status` CLI to accept `--type launchd`
- Configures `RunAtLoad`, `KeepAlive` (restart on failure), stdout/stderr log paths, and `PYTHONUNBUFFERED`

## Test plan
- [x] `uv run pytest tests/test_launchd_installer.py` — 18 passed
- [x] Full suite — 0 failures

Closes #18