### PR TITLE
feat: add AssemblyAI STT provider with streaming support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,12 @@ vosk = [
     "vosk>=0.3.45",
 ]
 
+# AssemblyAI real-time streaming STT
+assemblyai = [
+    "httpx>=0.25.0",
+    "websockets>=12.0",
+]
+
 # Speaker diarization / voice identification
 diarization = [
     "resemblyzer>=0.1.1",
@@ -96,7 +102,7 @@ diarization = [
 
 # All optional extras
 all = [
-    "champi-stt[torch,imgui,nlp,wakeword,vosk,diarization]",
+    "champi-stt[torch,imgui,nlp,wakeword,vosk,assemblyai,diarization]",
 ]
 
 # Development tools

--- a/src/champi_stt/factory.py
+++ b/src/champi_stt/factory.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from champi_stt.core.base_provider import BaseSTTProvider
 
-_SUPPORTED_PROVIDERS = ["whisperlive", "openai_whisper", "deepgram"]
+_SUPPORTED_PROVIDERS = ["whisperlive", "openai_whisper", "deepgram", "assemblyai"]
 
 
 def get_provider(
@@ -49,6 +49,13 @@ def get_provider(
         if config is None:
             config = DeepgramConfig(**config_kwargs) if config_kwargs else DeepgramConfig.from_env()
         return DeepgramProvider(config=config)
+
+    if provider_type == "assemblyai":
+        from champi_stt.providers.assemblyai import AssemblyAIConfig, AssemblyAIProvider
+
+        if config is None:
+            config = AssemblyAIConfig(**config_kwargs) if config_kwargs else AssemblyAIConfig.from_env()
+        return AssemblyAIProvider(config=config)
 
     raise ValueError(
         f"Unknown provider type: {provider_type!r}. "

--- a/src/champi_stt/providers/assemblyai/__init__.py
+++ b/src/champi_stt/providers/assemblyai/__init__.py
@@ -1,0 +1,19 @@
+"""AssemblyAI STT provider."""
+
+from champi_stt.providers.assemblyai.config import AssemblyAIConfig
+from champi_stt.providers.assemblyai.exceptions import (
+    AssemblyAIAuthError,
+    AssemblyAIConnectionError,
+    AssemblyAIError,
+    AssemblyAIStreamingError,
+)
+from champi_stt.providers.assemblyai.provider import AssemblyAIProvider
+
+__all__ = [
+    "AssemblyAIConfig",
+    "AssemblyAIError",
+    "AssemblyAIAuthError",
+    "AssemblyAIConnectionError",
+    "AssemblyAIStreamingError",
+    "AssemblyAIProvider",
+]

--- a/src/champi_stt/providers/assemblyai/config.py
+++ b/src/champi_stt/providers/assemblyai/config.py
@@ -1,0 +1,25 @@
+"""AssemblyAI provider configuration."""
+
+import os
+from dataclasses import dataclass
+
+from champi_stt.core.base_config import BaseSTTConfig
+
+
+@dataclass
+class AssemblyAIConfig(BaseSTTConfig):
+    """Configuration for the AssemblyAI STT provider."""
+
+    api_key: str = ""
+    sample_rate: int = 16000
+    encoding: str = "pcm_s16le"
+    word_boost: list[str] | None = None
+    disable_partial_transcripts: bool = False
+    end_utterance_silence_threshold: int = 700
+
+    @classmethod
+    def from_env(cls) -> "AssemblyAIConfig":
+        return cls(
+            api_key=os.environ.get("ASSEMBLYAI_API_KEY", ""),
+            sample_rate=int(os.environ.get("ASSEMBLYAI_SAMPLE_RATE", "16000")),
+        )

--- a/src/champi_stt/providers/assemblyai/exceptions.py
+++ b/src/champi_stt/providers/assemblyai/exceptions.py
@@ -1,0 +1,17 @@
+"""AssemblyAI provider exceptions."""
+
+
+class AssemblyAIError(Exception):
+    """Base exception for AssemblyAI provider errors."""
+
+
+class AssemblyAIAuthError(AssemblyAIError):
+    """Raised when the API key is missing or invalid."""
+
+
+class AssemblyAIConnectionError(AssemblyAIError):
+    """Raised when the WebSocket connection cannot be established."""
+
+
+class AssemblyAIStreamingError(AssemblyAIError):
+    """Raised when a streaming transcription error occurs."""

--- a/src/champi_stt/providers/assemblyai/provider.py
+++ b/src/champi_stt/providers/assemblyai/provider.py
@@ -1,0 +1,288 @@
+"""
+AssemblyAI real-time streaming STT provider.
+
+Uses the AssemblyAI WebSocket API for low-latency streaming transcription.
+Implements both one-shot transcription (via file upload REST API) and
+streaming transcription (via WebSocket).
+"""
+
+import asyncio
+import io
+import json
+import time
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from loguru import logger
+
+from champi_stt.core.base_provider import BaseSTTProvider
+from champi_stt.core.response import TranscriptionResponse, TranscriptionSegment
+from champi_stt.providers.assemblyai.config import AssemblyAIConfig
+from champi_stt.providers.assemblyai.exceptions import (
+    AssemblyAIAuthError,
+    AssemblyAIConnectionError,
+    AssemblyAIStreamingError,
+)
+
+try:
+    import httpx
+
+    HTTPX_AVAILABLE = True
+except ImportError:
+    httpx = None  # type: ignore[assignment]
+    HTTPX_AVAILABLE = False
+
+try:
+    import websockets
+
+    WEBSOCKETS_AVAILABLE = True
+except ImportError:
+    websockets = None  # type: ignore[assignment]
+    WEBSOCKETS_AVAILABLE = False
+
+try:
+    import soundfile as sf
+
+    SOUNDFILE_AVAILABLE = True
+except ImportError:
+    sf = None  # type: ignore[assignment]
+    SOUNDFILE_AVAILABLE = False
+
+_REST_BASE = "https://api.assemblyai.com/v2"
+_WS_URL = "wss://api.assemblyai.com/v2/realtime/ws"
+
+
+class AssemblyAIProvider(BaseSTTProvider):
+    """
+    AssemblyAI STT provider supporting both batch and real-time streaming.
+
+    Batch mode:   upload audio → poll for transcript → return result
+    Streaming:    open WebSocket → stream PCM chunks → yield partial results
+    """
+
+    name = "AssemblyAI"
+
+    def __init__(self, config: AssemblyAIConfig) -> None:
+        super().__init__(config)
+        self.config: AssemblyAIConfig = config
+        self._http: Any = None
+
+    async def initialize(self) -> None:
+        if self._initialized:
+            return
+
+        if not self.config.api_key:
+            raise AssemblyAIAuthError(
+                "AssemblyAI API key is required. Set ASSEMBLYAI_API_KEY or pass api_key in config."
+            )
+
+        if not HTTPX_AVAILABLE:
+            raise ImportError(
+                "httpx is required for AssemblyAIProvider. Install with: pip install httpx"
+            )
+
+        self._http = httpx.AsyncClient(
+            headers={"authorization": self.config.api_key},
+            timeout=120.0,
+        )
+        self._initialized = True
+        logger.info("AssemblyAI provider initialized")
+
+    async def shutdown(self) -> None:
+        if self._http:
+            await self._http.aclose()
+            self._http = None
+        self._initialized = False
+        logger.info("AssemblyAI provider shut down")
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._initialized
+
+    @property
+    def is_initialized(self) -> bool:
+        return self._initialized
+
+    async def transcribe(
+        self,
+        audio_data: bytes | np.ndarray | str,
+        language: str | None = None,
+        **kwargs: Any,
+    ) -> TranscriptionResponse:
+        if not self._initialized:
+            raise RuntimeError("Provider not initialized. Call initialize() first.")
+
+        start = time.perf_counter()
+
+        audio_bytes = await self._to_bytes(audio_data)
+        upload_url = await self._upload(audio_bytes)
+        result = await self._submit_and_poll(upload_url, language=language)
+
+        processing_time = time.perf_counter() - start
+        return self._parse_response(result, processing_time)
+
+    async def stream_transcribe(
+        self,
+        audio_source: AsyncIterator[np.ndarray],
+        language: str | None = None,
+    ) -> AsyncIterator[TranscriptionResponse]:
+        """
+        Stream audio chunks through the AssemblyAI real-time WebSocket API.
+
+        Args:
+            audio_source: Async iterator yielding int16 numpy audio chunks
+            language:     Language code (AssemblyAI auto-detects if None)
+
+        Yields:
+            TranscriptionResponse for each final transcript received
+        """
+        if not WEBSOCKETS_AVAILABLE:
+            raise ImportError(
+                "websockets is required for streaming. Install with: pip install websockets"
+            )
+        if not self._initialized:
+            raise RuntimeError("Provider not initialized. Call initialize() first.")
+
+        params = f"sample_rate={self.config.sample_rate}"
+        if language:
+            params += f"&language_code={language}"
+        if self.config.word_boost:
+            params += f"&word_boost={json.dumps(self.config.word_boost)}"
+        if self.config.disable_partial_transcripts:
+            params += "&disable_partial_transcripts=true"
+        params += f"&end_utterance_silence_threshold={self.config.end_utterance_silence_threshold}"
+
+        url = f"{_WS_URL}?{params}"
+        headers = {"Authorization": self.config.api_key}
+
+        try:
+            async with websockets.connect(url, additional_headers=headers) as ws:
+                # Confirm session
+                session_msg = json.loads(await ws.recv())
+                if session_msg.get("error"):
+                    raise AssemblyAIAuthError(session_msg["error"])
+                logger.debug(f"AssemblyAI session opened: {session_msg.get('session_id')}")
+
+                async def _send() -> None:
+                    async for chunk in audio_source:
+                        pcm = self._to_int16_bytes(chunk)
+                        await ws.send(pcm)
+                    # Signal end of stream
+                    await ws.send(json.dumps({"terminate_session": True}))
+
+                send_task = asyncio.create_task(_send())
+
+                try:
+                    async for raw in ws:
+                        msg = json.loads(raw)
+
+                        if msg.get("error"):
+                            raise AssemblyAIStreamingError(msg["error"])
+
+                        if msg.get("message_type") == "FinalTranscript":
+                            text = msg.get("text", "").strip()
+                            if text:
+                                yield TranscriptionResponse(
+                                    text=text,
+                                    language=msg.get("language_code", "unknown"),
+                                    duration=msg.get("audio_duration", 0.0),
+                                )
+                finally:
+                    send_task.cancel()
+
+        except (OSError, Exception) as exc:
+            if "websockets" in type(exc).__module__:
+                raise AssemblyAIConnectionError(f"WebSocket error: {exc}") from exc
+            raise
+
+    # ------------------------------------------------------------------ helpers
+
+    async def _upload(self, audio_bytes: bytes) -> str:
+        """Upload raw audio to AssemblyAI and return the upload URL."""
+        response = await self._http.post(
+            f"{_REST_BASE}/upload",
+            content=audio_bytes,
+            headers={"content-type": "application/octet-stream"},
+        )
+        response.raise_for_status()
+        return response.json()["upload_url"]
+
+    async def _submit_and_poll(
+        self, upload_url: str, language: str | None = None
+    ) -> dict[str, Any]:
+        """Submit a transcription job and poll until complete."""
+        payload: dict[str, Any] = {"audio_url": upload_url}
+        if language:
+            payload["language_code"] = language
+
+        submit = await self._http.post(f"{_REST_BASE}/transcript", json=payload)
+        submit.raise_for_status()
+        transcript_id = submit.json()["id"]
+        logger.debug(f"AssemblyAI transcript submitted: {transcript_id}")
+
+        poll_url = f"{_REST_BASE}/transcript/{transcript_id}"
+        while True:
+            await asyncio.sleep(1.0)
+            resp = await self._http.get(poll_url)
+            resp.raise_for_status()
+            data = resp.json()
+            status = data["status"]
+
+            if status == "completed":
+                return data
+            if status == "error":
+                raise AssemblyAIStreamingError(
+                    f"Transcription failed: {data.get('error', 'unknown error')}"
+                )
+
+    def _parse_response(
+        self, data: dict[str, Any], processing_time: float = 0.0
+    ) -> TranscriptionResponse:
+        words = data.get("words") or []
+        segments = [
+            TranscriptionSegment(
+                id=i,
+                start=w.get("start", 0) / 1000.0,
+                end=w.get("end", 0) / 1000.0,
+                text=w.get("text", ""),
+            )
+            for i, w in enumerate(words)
+        ]
+        return TranscriptionResponse(
+            text=data.get("text") or "",
+            language=data.get("language_code") or "unknown",
+            duration=data.get("audio_duration") or 0.0,
+            language_probability=data.get("language_confidence") or 0.0,
+            segments=segments,
+            processing_time=processing_time,
+        )
+
+    async def _to_bytes(self, audio: bytes | np.ndarray | str) -> bytes:
+        if isinstance(audio, bytes):
+            return audio
+        if isinstance(audio, (str, Path)):
+            return Path(audio).read_bytes()
+        if isinstance(audio, np.ndarray):
+            if not SOUNDFILE_AVAILABLE:
+                raise ImportError("soundfile required for numpy input. Install with: pip install soundfile")
+            buf = io.BytesIO()
+            sf.write(buf, audio, self.config.sample_rate, format="WAV", subtype="PCM_16")
+            return buf.getvalue()
+        raise TypeError(f"Unsupported audio type: {type(audio)}")
+
+    @staticmethod
+    def _to_int16_bytes(audio: np.ndarray) -> bytes:
+        if audio.dtype in (np.float32, np.float64):
+            audio = (audio * 32767).clip(-32768, 32767).astype(np.int16)
+        elif audio.dtype != np.int16:
+            audio = audio.astype(np.int16)
+        return audio.tobytes()
+
+    async def __aenter__(self) -> "AssemblyAIProvider":
+        await self.initialize()
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        await self.shutdown()

--- a/tests/test_assemblyai_provider.py
+++ b/tests/test_assemblyai_provider.py
@@ -1,0 +1,244 @@
+"""Tests for the AssemblyAI STT provider."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
+from champi_stt.core.response import TranscriptionResponse
+from champi_stt.providers.assemblyai.config import AssemblyAIConfig
+from champi_stt.providers.assemblyai.exceptions import (
+    AssemblyAIAuthError,
+    AssemblyAIStreamingError,
+)
+from champi_stt.providers.assemblyai.provider import AssemblyAIProvider
+
+_SAMPLE_COMPLETED = {
+    "status": "completed",
+    "text": "hello assemblyai",
+    "language_code": "en",
+    "audio_duration": 2.5,
+    "language_confidence": 0.98,
+    "words": [
+        {"text": "hello", "start": 0, "end": 500},
+        {"text": "assemblyai", "start": 600, "end": 1200},
+    ],
+}
+
+
+@pytest.fixture
+def config():
+    return AssemblyAIConfig(api_key="test-key")
+
+
+@pytest.fixture
+def provider(config):
+    return AssemblyAIProvider(config)
+
+
+class TestAssemblyAIConfig:
+    def test_defaults(self):
+        cfg = AssemblyAIConfig(api_key="k")
+        assert cfg.sample_rate == 16000
+        assert cfg.encoding == "pcm_s16le"
+
+    def test_from_env(self, monkeypatch):
+        monkeypatch.setenv("ASSEMBLYAI_API_KEY", "env-key")
+        cfg = AssemblyAIConfig.from_env()
+        assert cfg.api_key == "env-key"
+
+
+class TestAssemblyAIProvider:
+    def test_provider_name(self, provider):
+        assert provider.name == "AssemblyAI"
+        assert not provider.is_initialized
+
+    @pytest.mark.asyncio
+    async def test_initialize_missing_key(self):
+        p = AssemblyAIProvider(AssemblyAIConfig(api_key=""))
+        with pytest.raises(AssemblyAIAuthError):
+            await p.initialize()
+
+    @pytest.mark.asyncio
+    async def test_initialize_missing_httpx(self, config):
+        p = AssemblyAIProvider(config)
+        with patch("champi_stt.providers.assemblyai.provider.HTTPX_AVAILABLE", False):
+            with pytest.raises(ImportError):
+                await p.initialize()
+
+    @pytest.mark.asyncio
+    async def test_initialize_success(self, config):
+        mock_httpx = MagicMock()
+        mock_client = MagicMock()
+        mock_httpx.AsyncClient.return_value = mock_client
+
+        p = AssemblyAIProvider(config)
+        with patch("champi_stt.providers.assemblyai.provider.HTTPX_AVAILABLE", True):
+            with patch("champi_stt.providers.assemblyai.provider.httpx", mock_httpx):
+                await p.initialize()
+        assert p.is_initialized
+
+    @pytest.mark.asyncio
+    async def test_shutdown(self, config):
+        mock_client = AsyncMock()
+        p = AssemblyAIProvider(config)
+        p._initialized = True
+        p._http = mock_client
+        await p.shutdown()
+        assert not p.is_initialized
+        assert p._http is None
+        mock_client.aclose.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_transcribe_bytes(self, config):
+        upload_resp = MagicMock()
+        upload_resp.raise_for_status = MagicMock()
+        upload_resp.json.return_value = {"upload_url": "https://cdn.assemblyai.com/upload/test"}
+
+        submit_resp = MagicMock()
+        submit_resp.raise_for_status = MagicMock()
+        submit_resp.json.return_value = {"id": "abc123", "status": "queued"}
+
+        poll_resp = MagicMock()
+        poll_resp.raise_for_status = MagicMock()
+        poll_resp.json.return_value = _SAMPLE_COMPLETED
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=[upload_resp, submit_resp])
+        mock_client.get = AsyncMock(return_value=poll_resp)
+
+        p = AssemblyAIProvider(config)
+        p._initialized = True
+        p._http = mock_client
+
+        result = await p.transcribe(b"\x00" * 100)
+        assert isinstance(result, TranscriptionResponse)
+        assert result.text == "hello assemblyai"
+        assert result.language == "en"
+        assert len(result.segments) == 2
+
+    @pytest.mark.asyncio
+    async def test_transcribe_file(self, tmp_path, config):
+        audio_file = tmp_path / "audio.wav"
+        audio_file.write_bytes(b"RIFF" + b"\x00" * 100)
+
+        upload_resp = MagicMock()
+        upload_resp.raise_for_status = MagicMock()
+        upload_resp.json.return_value = {"upload_url": "https://cdn.assemblyai.com/upload/test"}
+
+        submit_resp = MagicMock()
+        submit_resp.raise_for_status = MagicMock()
+        submit_resp.json.return_value = {"id": "abc123", "status": "queued"}
+
+        poll_resp = MagicMock()
+        poll_resp.raise_for_status = MagicMock()
+        poll_resp.json.return_value = _SAMPLE_COMPLETED
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=[upload_resp, submit_resp])
+        mock_client.get = AsyncMock(return_value=poll_resp)
+
+        p = AssemblyAIProvider(config)
+        p._initialized = True
+        p._http = mock_client
+
+        result = await p.transcribe(str(audio_file))
+        assert result.text == "hello assemblyai"
+
+    @pytest.mark.asyncio
+    async def test_transcribe_error_status(self, config):
+        upload_resp = MagicMock()
+        upload_resp.raise_for_status = MagicMock()
+        upload_resp.json.return_value = {"upload_url": "https://test"}
+
+        submit_resp = MagicMock()
+        submit_resp.raise_for_status = MagicMock()
+        submit_resp.json.return_value = {"id": "abc", "status": "queued"}
+
+        error_resp = MagicMock()
+        error_resp.raise_for_status = MagicMock()
+        error_resp.json.return_value = {"status": "error", "error": "bad audio"}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=[upload_resp, submit_resp])
+        mock_client.get = AsyncMock(return_value=error_resp)
+
+        p = AssemblyAIProvider(config)
+        p._initialized = True
+        p._http = mock_client
+
+        with pytest.raises(AssemblyAIStreamingError, match="bad audio"):
+            await p.transcribe(b"\x00" * 100)
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self, config):
+        mock_httpx = MagicMock()
+        mock_httpx.AsyncClient.return_value = AsyncMock()
+
+        with patch("champi_stt.providers.assemblyai.provider.HTTPX_AVAILABLE", True):
+            with patch("champi_stt.providers.assemblyai.provider.httpx", mock_httpx):
+                async with AssemblyAIProvider(config) as p:
+                    assert p.is_initialized
+        assert not p.is_initialized
+
+    @pytest.mark.asyncio
+    async def test_transcribe_numpy(self, config):
+        audio = np.zeros(16000, dtype=np.float32)
+
+        upload_resp = MagicMock()
+        upload_resp.raise_for_status = MagicMock()
+        upload_resp.json.return_value = {"upload_url": "https://test"}
+
+        submit_resp = MagicMock()
+        submit_resp.raise_for_status = MagicMock()
+        submit_resp.json.return_value = {"id": "abc", "status": "queued"}
+
+        poll_resp = MagicMock()
+        poll_resp.raise_for_status = MagicMock()
+        poll_resp.json.return_value = _SAMPLE_COMPLETED
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=[upload_resp, submit_resp])
+        mock_client.get = AsyncMock(return_value=poll_resp)
+
+        p = AssemblyAIProvider(config)
+        p._initialized = True
+        p._http = mock_client
+
+        import soundfile as sf_mod
+        with patch("champi_stt.providers.assemblyai.provider.SOUNDFILE_AVAILABLE", True):
+            with patch("champi_stt.providers.assemblyai.provider.sf", sf_mod):
+                result = await p.transcribe(audio)
+        assert isinstance(result, TranscriptionResponse)
+
+
+class TestParseResponse:
+    def test_basic_parse(self, provider):
+        result = provider._parse_response(_SAMPLE_COMPLETED)
+        assert result.text == "hello assemblyai"
+        assert result.language == "en"
+        assert result.duration == pytest.approx(2.5)
+        assert len(result.segments) == 2
+
+    def test_empty_words(self, provider):
+        result = provider._parse_response({"status": "completed", "text": "hi", "words": []})
+        assert result.text == "hi"
+        assert result.segments == []
+
+    def test_none_text(self, provider):
+        result = provider._parse_response({"status": "completed", "text": None, "words": None})
+        assert result.text == ""
+
+
+class TestToInt16Bytes:
+    def test_float32(self):
+        audio = np.array([0.5, -0.5], dtype=np.float32)
+        result = AssemblyAIProvider._to_int16_bytes(audio)
+        assert isinstance(result, bytes)
+        assert len(result) == 4
+
+    def test_int16_passthrough(self):
+        audio = np.array([100, -100], dtype=np.int16)
+        result = AssemblyAIProvider._to_int16_bytes(audio)
+        assert len(result) == 4


### PR DESCRIPTION
## Summary

- Adds `src/champi_stt/providers/assemblyai/` with config, exceptions, and provider
- `AssemblyAIProvider.transcribe()` — batch mode: upload → poll REST API
- `AssemblyAIProvider.stream_transcribe()` — real-time WebSocket streaming via async generator
- Registered in `factory.py` under key `assemblyai`
- Adds `assemblyai` optional extra (`httpx>=0.25.0`, `websockets>=12.0`)

## Test plan
- [x] `uv run pytest tests/test_assemblyai_provider.py` — 17 passed
- [x] Full suite — 263 passed, 0 failures

Closes #19