### PR TITLE
feat: web configuration UI server (#20)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,12 @@ assemblyai = [
     "websockets>=12.0",
 ]
 
+# Web configuration UI
+webui = [
+    "fastapi>=0.100.0",
+    "uvicorn>=0.23.0",
+]
+
 # Speaker diarization / voice identification
 diarization = [
     "resemblyzer>=0.1.1",
@@ -102,7 +108,7 @@ diarization = [
 
 # All optional extras
 all = [
-    "champi-stt[torch,imgui,nlp,wakeword,vosk,assemblyai,diarization]",
+    "champi-stt[torch,imgui,nlp,wakeword,vosk,assemblyai,diarization,webui]",
 ]
 
 # Development tools

--- a/src/champi_stt/assistant/web/__init__.py
+++ b/src/champi_stt/assistant/web/__init__.py
@@ -1,0 +1,1 @@
+"""Web configuration UI for the champi-stt assistant."""

--- a/src/champi_stt/assistant/web/server.py
+++ b/src/champi_stt/assistant/web/server.py
@@ -1,0 +1,225 @@
+"""
+Lightweight web configuration server for champi-stt.
+
+Serves a browser UI at http://localhost:8765 to view and edit the
+assistant configuration YAML. Changes are validated and written to disk;
+an optional reload callback lets the caller hot-reload the running daemon.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import yaml
+from loguru import logger
+
+try:
+    from fastapi import FastAPI, HTTPException, Request
+    from fastapi.responses import HTMLResponse, JSONResponse
+    import uvicorn
+
+    FASTAPI_AVAILABLE = True
+except ImportError:
+    FASTAPI_AVAILABLE = False
+
+from champi_stt.assistant.service.config import AssistantConfig
+
+_DEFAULT_HOST = "localhost"
+_DEFAULT_PORT = 8765
+
+
+def _config_to_dict(cfg: AssistantConfig) -> dict[str, Any]:
+    return dataclasses.asdict(cfg)
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+
+def _save_yaml(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=True)
+
+
+def _build_html(config_json: str) -> str:
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Champi STT — Configuration</title>
+  <style>
+    body {{ font-family: system-ui, sans-serif; max-width: 900px; margin: 2rem auto; padding: 0 1rem; }}
+    h1 {{ color: #333; }}
+    textarea {{ width: 100%; height: 400px; font-family: monospace; font-size: 0.9rem; padding: 0.5rem; border: 1px solid #ccc; border-radius: 4px; box-sizing: border-box; }}
+    .btn {{ padding: 0.5rem 1.2rem; border: none; border-radius: 4px; cursor: pointer; font-size: 0.95rem; margin-right: 0.5rem; }}
+    .btn-save {{ background: #2563eb; color: white; }}
+    .btn-reload {{ background: #16a34a; color: white; }}
+    .btn-save:hover {{ background: #1d4ed8; }}
+    .btn-reload:hover {{ background: #15803d; }}
+    #status {{ margin-top: 1rem; padding: 0.5rem 0.75rem; border-radius: 4px; display: none; }}
+    .ok {{ background: #dcfce7; color: #166534; }}
+    .err {{ background: #fee2e2; color: #991b1b; }}
+    pre {{ background: #f3f4f6; padding: 1rem; border-radius: 4px; overflow: auto; }}
+  </style>
+</head>
+<body>
+  <h1>Champi STT — Configuration</h1>
+  <p>Edit the assistant configuration below. Changes are saved to disk immediately.</p>
+  <textarea id="cfg" spellcheck="false"></textarea>
+  <br><br>
+  <button class="btn btn-save" onclick="save()">Save</button>
+  <button class="btn btn-reload" onclick="reload()">Save &amp; Reload Daemon</button>
+  <div id="status"></div>
+
+  <script>
+    const raw = {config_json};
+    function toYaml(obj, indent) {{
+      // Simple JSON display — server stores YAML
+      return JSON.stringify(obj, null, 2);
+    }}
+    document.getElementById('cfg').value = JSON.stringify(raw, null, 2);
+
+    function showStatus(msg, ok) {{
+      const el = document.getElementById('status');
+      el.textContent = msg;
+      el.className = ok ? 'ok' : 'err';
+      el.style.display = 'block';
+      setTimeout(() => {{ el.style.display = 'none'; }}, 4000);
+    }}
+
+    async function save() {{
+      let data;
+      try {{ data = JSON.parse(document.getElementById('cfg').value); }}
+      catch(e) {{ showStatus('JSON parse error: ' + e.message, false); return; }}
+      const r = await fetch('/config', {{
+        method: 'POST',
+        headers: {{'Content-Type': 'application/json'}},
+        body: JSON.stringify(data)
+      }});
+      const body = await r.json();
+      showStatus(r.ok ? 'Saved.' : ('Error: ' + body.detail), r.ok);
+    }}
+
+    async function reload() {{
+      let data;
+      try {{ data = JSON.parse(document.getElementById('cfg').value); }}
+      catch(e) {{ showStatus('JSON parse error: ' + e.message, false); return; }}
+      const r = await fetch('/config/reload', {{
+        method: 'POST',
+        headers: {{'Content-Type': 'application/json'}},
+        body: JSON.stringify(data)
+      }});
+      const body = await r.json();
+      showStatus(r.ok ? 'Saved and daemon reload triggered.' : ('Error: ' + body.detail), r.ok);
+    }}
+  </script>
+</body>
+</html>
+"""
+
+
+def create_app(
+    config_path: str | Path,
+    reload_callback: Callable[[], None] | None = None,
+) -> "FastAPI":
+    """
+    Build the FastAPI application.
+
+    Args:
+        config_path:     Path to the YAML config file to read/write.
+        reload_callback: Optional callable invoked after a save+reload request.
+                         Use this to signal the running daemon to reload config.
+
+    Returns:
+        Configured FastAPI application instance.
+    """
+    if not FASTAPI_AVAILABLE:
+        raise ImportError(
+            "fastapi and uvicorn are required for the web UI. "
+            "Install with: pip install fastapi uvicorn"
+        )
+
+    app = FastAPI(title="Champi STT Config", docs_url=None, redoc_url=None)
+    _path = Path(config_path)
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index() -> HTMLResponse:
+        data = _load_yaml(_path)
+        return HTMLResponse(_build_html(json.dumps(data)))
+
+    @app.get("/config")
+    async def get_config() -> JSONResponse:
+        return JSONResponse(_load_yaml(_path))
+
+    @app.post("/config")
+    async def save_config(request: Request) -> JSONResponse:
+        try:
+            data: dict[str, Any] = await request.json()
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=f"Invalid JSON: {exc}") from exc
+
+        try:
+            _save_yaml(_path, data)
+            logger.info(f"Config saved to {_path}")
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+        return JSONResponse({"status": "saved"})
+
+    @app.post("/config/reload")
+    async def save_and_reload(request: Request) -> JSONResponse:
+        try:
+            data: dict[str, Any] = await request.json()
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=f"Invalid JSON: {exc}") from exc
+
+        try:
+            _save_yaml(_path, data)
+            logger.info(f"Config saved to {_path}")
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+        if reload_callback:
+            try:
+                reload_callback()
+                logger.info("Daemon reload triggered")
+            except Exception as exc:
+                logger.warning(f"Reload callback failed: {exc}")
+
+        return JSONResponse({"status": "saved", "reload": reload_callback is not None})
+
+    return app
+
+
+def serve(
+    config_path: str | Path,
+    host: str = _DEFAULT_HOST,
+    port: int = _DEFAULT_PORT,
+    reload_callback: Callable[[], None] | None = None,
+) -> None:
+    """
+    Start the configuration web server (blocking).
+
+    Args:
+        config_path:     Path to the YAML config file.
+        host:            Bind address (default: localhost).
+        port:            Port to listen on (default: 8765).
+        reload_callback: Called when the browser requests save+reload.
+    """
+    if not FASTAPI_AVAILABLE:
+        raise ImportError(
+            "fastapi and uvicorn are required. Install with: pip install fastapi uvicorn"
+        )
+
+    app = create_app(config_path, reload_callback=reload_callback)
+    logger.info(f"Starting config server at http://{host}:{port}")
+    uvicorn.run(app, host=host, port=port, log_level="warning")

--- a/src/champi_stt/cli.py
+++ b/src/champi_stt/cli.py
@@ -505,6 +505,23 @@ def test_ui(prefix):
         click.echo(f"❌ Error: {e}")
 
 
+@cli.command("serve-config")
+@click.option("--config", default=None, help="Path to assistant_config.yaml")
+@click.option("--host", default="localhost", show_default=True, help="Bind address")
+@click.option("--port", default=8765, show_default=True, help="Port to listen on")
+def serve_config(config, host, port):
+    """Start the web configuration UI (http://localhost:8765 by default)."""
+    from champi_stt.assistant.web.server import serve
+
+    config_path = config or "~/.config/champi-stt/assistant_config.yaml"
+    click.echo(f"Config UI: http://{host}:{port}")
+    try:
+        serve(config_path, host=host, port=port)
+    except ImportError as e:
+        click.echo(f"Error: {e}", err=True)
+        raise SystemExit(1)
+
+
 @cli.group()
 def service():
     """Manage the champi-stt system service."""

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1,0 +1,165 @@
+"""Tests for the web configuration server."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def config_file(tmp_path: Path) -> Path:
+    cfg = tmp_path / "assistant_config.yaml"
+    cfg.write_text(yaml.dump({"llm": {"model": "gpt-4o"}, "stt": {"provider": "whisperlive"}}))
+    return cfg
+
+
+@pytest.fixture
+def empty_config_file(tmp_path: Path) -> Path:
+    return tmp_path / "nonexistent.yaml"
+
+
+class TestLoadSaveYaml:
+    def test_load_existing(self, config_file: Path) -> None:
+        from champi_stt.assistant.web.server import _load_yaml
+
+        data = _load_yaml(config_file)
+        assert data["stt"]["provider"] == "whisperlive"
+
+    def test_load_missing_returns_empty(self, empty_config_file: Path) -> None:
+        from champi_stt.assistant.web.server import _load_yaml
+
+        assert _load_yaml(empty_config_file) == {}
+
+    def test_save_creates_parents(self, tmp_path: Path) -> None:
+        from champi_stt.assistant.web.server import _save_yaml
+
+        target = tmp_path / "sub" / "dir" / "config.yaml"
+        _save_yaml(target, {"key": "value"})
+        assert target.exists()
+        loaded = yaml.safe_load(target.read_text())
+        assert loaded["key"] == "value"
+
+    def test_save_overwrites(self, config_file: Path) -> None:
+        from champi_stt.assistant.web.server import _save_yaml, _load_yaml
+
+        _save_yaml(config_file, {"new": "data"})
+        assert _load_yaml(config_file) == {"new": "data"}
+
+
+class TestBuildHtml:
+    def test_contains_config_json(self) -> None:
+        from champi_stt.assistant.web.server import _build_html
+
+        html = _build_html('{"key": "val"}')
+        assert '{"key": "val"}' in html
+
+    def test_contains_save_function(self) -> None:
+        from champi_stt.assistant.web.server import _build_html
+
+        html = _build_html("{}")
+        assert "function save()" in html
+        assert "function reload()" in html
+
+    def test_html_structure(self) -> None:
+        from champi_stt.assistant.web.server import _build_html
+
+        html = _build_html("{}")
+        assert "<!DOCTYPE html>" in html
+        assert "<textarea" in html
+
+
+class TestCreateApp:
+    def test_raises_without_fastapi(self, config_file: Path) -> None:
+        with patch("champi_stt.assistant.web.server.FASTAPI_AVAILABLE", False):
+            from champi_stt.assistant.web.server import create_app
+
+            with pytest.raises(ImportError, match="fastapi"):
+                create_app(config_file)
+
+    def test_get_index(self, config_file: Path) -> None:
+        pytest.importorskip("fastapi")
+        from fastapi.testclient import TestClient
+        from champi_stt.assistant.web.server import create_app
+
+        client = TestClient(create_app(config_file))
+        r = client.get("/")
+        assert r.status_code == 200
+        assert "text/html" in r.headers["content-type"]
+
+    def test_get_config(self, config_file: Path) -> None:
+        pytest.importorskip("fastapi")
+        from fastapi.testclient import TestClient
+        from champi_stt.assistant.web.server import create_app
+
+        client = TestClient(create_app(config_file))
+        r = client.get("/config")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["stt"]["provider"] == "whisperlive"
+
+    def test_post_config_saves(self, config_file: Path) -> None:
+        pytest.importorskip("fastapi")
+        from fastapi.testclient import TestClient
+        from champi_stt.assistant.web.server import create_app
+
+        client = TestClient(create_app(config_file))
+        r = client.post("/config", json={"stt": {"provider": "deepgram"}})
+        assert r.status_code == 200
+        assert r.json()["status"] == "saved"
+        loaded = yaml.safe_load(config_file.read_text())
+        assert loaded["stt"]["provider"] == "deepgram"
+
+    def test_post_config_reload_triggers_callback(self, config_file: Path) -> None:
+        pytest.importorskip("fastapi")
+        from fastapi.testclient import TestClient
+        from champi_stt.assistant.web.server import create_app
+
+        callback = MagicMock()
+        client = TestClient(create_app(config_file, reload_callback=callback))
+        r = client.post("/config/reload", json={"stt": {"provider": "deepgram"}})
+        assert r.status_code == 200
+        assert r.json()["reload"] is True
+        callback.assert_called_once()
+
+    def test_post_config_reload_no_callback(self, config_file: Path) -> None:
+        pytest.importorskip("fastapi")
+        from fastapi.testclient import TestClient
+        from champi_stt.assistant.web.server import create_app
+
+        client = TestClient(create_app(config_file))
+        r = client.post("/config/reload", json={"key": "v"})
+        assert r.status_code == 200
+        assert r.json()["reload"] is False
+
+    def test_get_index_missing_config(self, empty_config_file: Path) -> None:
+        pytest.importorskip("fastapi")
+        from fastapi.testclient import TestClient
+        from champi_stt.assistant.web.server import create_app
+
+        client = TestClient(create_app(empty_config_file))
+        r = client.get("/")
+        assert r.status_code == 200
+
+
+class TestServe:
+    def test_raises_without_fastapi(self, config_file: Path) -> None:
+        with patch("champi_stt.assistant.web.server.FASTAPI_AVAILABLE", False):
+            from champi_stt.assistant.web.server import serve
+
+            with pytest.raises(ImportError):
+                serve(config_file)
+
+    def test_calls_uvicorn_run(self, config_file: Path) -> None:
+        pytest.importorskip("fastapi")
+        with patch("champi_stt.assistant.web.server.uvicorn") as mock_uvicorn:
+            from champi_stt.assistant.web.server import serve
+
+            serve(config_file, host="127.0.0.1", port=9000)
+            mock_uvicorn.run.assert_called_once()
+            _, kwargs = mock_uvicorn.run.call_args
+            assert kwargs["host"] == "127.0.0.1"
+            assert kwargs["port"] == 9000


### PR DESCRIPTION
## Summary

- Adds `src/champi_stt/assistant/web/server.py` with a FastAPI app serving a browser UI at `http://localhost:8765`
- Endpoints: `GET /` (HTML UI), `GET /config` (current YAML as JSON), `POST /config` (save), `POST /config/reload` (save + optional daemon reload callback)
- Adds `champi-stt serve-config` CLI command with `--config`, `--host`, `--port` options
- Adds `webui` optional extra (`fastapi>=0.100.0`, `uvicorn>=0.23.0`) to `pyproject.toml`
- 9 unit tests in `tests/test_web_server.py`

## Test plan

- [ ] `uv run pytest tests/test_web_server.py -v` passes (9 pass, 7 skipped without fastapi installed)
- [ ] `pip install champi-stt[webui]` installs cleanly and `champi-stt serve-config --help` shows the command