### PR TITLE
feat: configurable sound themes for audio feedback (#21)

### DIFF
--- a/src/champi_stt/assistant/audio_feedback.py
+++ b/src/champi_stt/assistant/audio_feedback.py
@@ -1,10 +1,14 @@
 """Audio feedback system for assistant notifications.
 
-Provides simple chime sounds for wake word detection and recording states.
+Provides chime sounds for wake word detection and recording states,
+with configurable themes and volume control.
 """
 
-import asyncio
+from __future__ import annotations
+
 import logging
+import threading
+from enum import Enum
 from typing import Literal
 
 import numpy as np
@@ -12,8 +16,44 @@ import numpy as np
 logger = logging.getLogger(__name__)
 
 
+class FeedbackTheme(str, Enum):
+    """Sound theme for audio feedback."""
+
+    DEFAULT = "default"
+    MINIMAL = "minimal"
+    SILENT = "silent"
+
+
+_THEME_FREQS: dict[FeedbackTheme, dict[str, list[float]]] = {
+    FeedbackTheme.DEFAULT: {
+        "wake": [1000.0, 1200.0, 1400.0],
+        "listening": [800.0, 1000.0],
+        "finished": [1000.0, 800.0],
+    },
+    FeedbackTheme.MINIMAL: {
+        "wake": [1200.0],
+        "listening": [900.0],
+        "finished": [700.0],
+    },
+    FeedbackTheme.SILENT: {
+        "wake": [],
+        "listening": [],
+        "finished": [],
+    },
+}
+
+_THEME_DURATIONS: dict[FeedbackTheme, float] = {
+    FeedbackTheme.DEFAULT: 0.1,
+    FeedbackTheme.MINIMAL: 0.06,
+    FeedbackTheme.SILENT: 0.0,
+}
+
+
 def generate_chime(
-    frequencies: list[float], duration: float = 0.1, sample_rate: int = 16000
+    frequencies: list[float],
+    duration: float = 0.1,
+    sample_rate: int = 16000,
+    volume: float = 1.0,
 ) -> np.ndarray:
     """Generate a chime sound with given frequencies.
 
@@ -21,103 +61,123 @@ def generate_chime(
         frequencies: List of frequencies to play in sequence
         duration: Duration of each tone in seconds
         sample_rate: Sample rate for audio generation
+        volume: Amplitude multiplier in [0.0, 1.0]
 
     Returns:
-        Numpy array of audio samples
+        Numpy array of audio samples (float32)
     """
+    if not frequencies or duration <= 0:
+        return np.zeros(0, dtype=np.float32)
+
+    volume = float(np.clip(volume, 0.0, 1.0))
     samples_per_tone = int(sample_rate * duration)
-    fade_samples = int(sample_rate * 0.01)  # 10ms fade
+    fade_samples = max(1, int(sample_rate * 0.01))  # 10 ms fade
 
-    all_samples = []
+    all_samples: list[np.ndarray] = []
     for freq in frequencies:
-        # Generate sine wave
         t = np.linspace(0, duration, samples_per_tone, endpoint=False)
-        tone = np.sin(2 * np.pi * freq * t)
+        tone: np.ndarray = np.sin(2 * np.pi * freq * t)
 
-        # Apply fade in/out
         fade_in = np.linspace(0, 1, fade_samples)
         fade_out = np.linspace(1, 0, fade_samples)
-
         tone[:fade_samples] *= fade_in
         tone[-fade_samples:] *= fade_out
 
-        all_samples.append(tone)
+        all_samples.append(tone * volume)
 
-    # Concatenate all tones
-    return np.concatenate(all_samples).astype(np.float32)
+    result: np.ndarray = np.concatenate(all_samples).astype(np.float32)
+    return result
 
 
-async def play_chime_start(sample_rate: int = 16000) -> bool:
-    """Play the recording start chime (ascending tones).
+def _play_nonblocking(audio: np.ndarray, sample_rate: int) -> None:
+    """Play audio on a background thread so the caller is never blocked."""
+
+    def _run() -> None:
+        try:
+            import sounddevice as sd  # type: ignore[import-untyped]
+
+            sd.play(audio, sample_rate, latency="high")
+            sd.wait()
+        except Exception as exc:
+            logger.debug(f"Audio playback failed: {exc}")
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+
+
+def _device_sample_rate() -> int:
+    try:
+        import sounddevice as sd  # type: ignore[import-untyped]
+
+        device = sd.query_devices(kind="output")
+        return int(device["default_samplerate"])
+    except Exception:
+        return 44100
+
+
+async def play_chime_start(
+    theme: FeedbackTheme = FeedbackTheme.DEFAULT,
+    volume: float = 1.0,
+) -> bool:
+    """Play the recording start chime.
 
     Returns:
-        True if chime played successfully, False otherwise
+        True if chime was dispatched, False on error.
     """
+    if theme is FeedbackTheme.SILENT:
+        return True
     try:
-        import sounddevice as sd
-
-        # Get default output device sample rate
-        try:
-            default_device = sd.query_devices(kind="output")
-            device_rate = int(default_device["default_samplerate"])
-        except Exception:
-            device_rate = 44100  # Fallback to common rate
-
-        chime = generate_chime([800, 1000], duration=0.1, sample_rate=device_rate)
-        sd.play(chime, device_rate, latency="high")  # Allow shared device access
-        sd.wait()
+        rate = _device_sample_rate()
+        freqs = _THEME_FREQS[theme]["listening"]
+        dur = _THEME_DURATIONS[theme]
+        audio = generate_chime(freqs, duration=dur, sample_rate=rate, volume=volume)
+        _play_nonblocking(audio, rate)
         return True
     except Exception as e:
         logger.debug(f"Could not play start chime: {e}")
         return False
 
 
-async def play_chime_end(sample_rate: int = 16000) -> bool:
-    """Play the recording end chime (descending tones).
+async def play_chime_end(
+    theme: FeedbackTheme = FeedbackTheme.DEFAULT,
+    volume: float = 1.0,
+) -> bool:
+    """Play the recording end chime.
 
     Returns:
-        True if chime played successfully, False otherwise
+        True if chime was dispatched, False on error.
     """
+    if theme is FeedbackTheme.SILENT:
+        return True
     try:
-        import sounddevice as sd
-
-        # Get default output device sample rate
-        try:
-            default_device = sd.query_devices(kind="output")
-            device_rate = int(default_device["default_samplerate"])
-        except Exception:
-            device_rate = 44100  # Fallback to common rate
-
-        chime = generate_chime([1000, 800], duration=0.1, sample_rate=device_rate)
-        sd.play(chime, device_rate, latency="high")  # Allow shared device access
-        sd.wait()
+        rate = _device_sample_rate()
+        freqs = _THEME_FREQS[theme]["finished"]
+        dur = _THEME_DURATIONS[theme]
+        audio = generate_chime(freqs, duration=dur, sample_rate=rate, volume=volume)
+        _play_nonblocking(audio, rate)
         return True
     except Exception as e:
         logger.debug(f"Could not play end chime: {e}")
         return False
 
 
-async def play_chime_wake(sample_rate: int = 16000) -> bool:
-    """Play the wake word detected chime (high ascending tones).
+async def play_chime_wake(
+    theme: FeedbackTheme = FeedbackTheme.DEFAULT,
+    volume: float = 1.0,
+) -> bool:
+    """Play the wake word detected chime.
 
     Returns:
-        True if chime played successfully, False otherwise
+        True if chime was dispatched, False on error.
     """
+    if theme is FeedbackTheme.SILENT:
+        return True
     try:
-        import sounddevice as sd
-
-        # Get default output device sample rate
-        try:
-            default_device = sd.query_devices(kind="output")
-            device_rate = int(default_device["default_samplerate"])
-        except Exception:
-            device_rate = 44100  # Fallback to common rate
-
-        chime = generate_chime(
-            [1000, 1200, 1400], duration=0.08, sample_rate=device_rate
-        )
-        sd.play(chime, device_rate, latency="high")  # Allow shared device access
-        sd.wait()
+        rate = _device_sample_rate()
+        freqs = _THEME_FREQS[theme]["wake"]
+        dur = _THEME_DURATIONS[theme]
+        audio = generate_chime(freqs, duration=dur, sample_rate=rate, volume=volume)
+        _play_nonblocking(audio, rate)
         return True
     except Exception as e:
         logger.debug(f"Could not play wake chime: {e}")
@@ -125,45 +185,46 @@ async def play_chime_wake(sample_rate: int = 16000) -> bool:
 
 
 async def play_audio_feedback(
-    feedback_type: Literal["listening", "finished", "wake"], enabled: bool | None = None
+    feedback_type: Literal["listening", "finished", "wake"],
+    enabled: bool | None = None,
+    theme: FeedbackTheme = FeedbackTheme.DEFAULT,
+    volume: float = 1.0,
 ) -> None:
     """Play audio feedback chime.
 
     Args:
         feedback_type: Type of feedback ("listening", "finished", or "wake")
         enabled: Whether feedback is enabled (None means always play)
+        theme: Sound theme to use
+        volume: Amplitude multiplier in [0.0, 1.0]
     """
     if enabled is False:
         return
 
     try:
         if feedback_type == "listening":
-            await play_chime_start()
+            await play_chime_start(theme=theme, volume=volume)
         elif feedback_type == "finished":
-            await play_chime_end()
+            await play_chime_end(theme=theme, volume=volume)
         elif feedback_type == "wake":
-            await play_chime_wake()
+            await play_chime_wake(theme=theme, volume=volume)
         else:
             logger.warning(f"Unknown feedback type: {feedback_type}")
     except Exception as e:
         logger.debug(f"Audio feedback failed: {e}")
 
 
-# Run chime test if module is executed directly
 if __name__ == "__main__":
     import asyncio
 
-    async def test_chimes():
-        """Test all chime sounds."""
-        logger.info("Testing wake chime...")
-        await play_audio_feedback("wake")
-        await asyncio.sleep(0.5)
+    async def _test() -> None:
+        for theme in FeedbackTheme:
+            print(f"Theme: {theme.value}")
+            await play_audio_feedback("wake", theme=theme)
+            await asyncio.sleep(0.5)
+            await play_audio_feedback("listening", theme=theme)
+            await asyncio.sleep(0.5)
+            await play_audio_feedback("finished", theme=theme)
+            await asyncio.sleep(0.5)
 
-        logger.info("Testing listening chime...")
-        await play_audio_feedback("listening")
-        await asyncio.sleep(0.5)
-
-        logger.info("Testing finished chime...")
-        await play_audio_feedback("finished")
-
-    asyncio.run(test_chimes())
+    asyncio.run(_test())

--- a/tests/test_audio_feedback.py
+++ b/tests/test_audio_feedback.py
@@ -1,0 +1,148 @@
+"""Tests for audio feedback system."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from champi_stt.assistant.audio_feedback import (
+    FeedbackTheme,
+    generate_chime,
+    play_audio_feedback,
+    play_chime_end,
+    play_chime_start,
+    play_chime_wake,
+)
+
+
+class TestFeedbackTheme:
+    def test_values(self) -> None:
+        assert FeedbackTheme.DEFAULT == "default"
+        assert FeedbackTheme.MINIMAL == "minimal"
+        assert FeedbackTheme.SILENT == "silent"
+
+    def test_is_str_enum(self) -> None:
+        assert isinstance(FeedbackTheme.DEFAULT, str)
+
+
+class TestGenerateChime:
+    def test_basic_output_shape(self) -> None:
+        audio = generate_chime([440.0, 880.0], duration=0.1, sample_rate=16000)
+        assert audio.dtype == np.float32
+        assert len(audio) == 2 * int(16000 * 0.1)
+
+    def test_empty_frequencies_returns_empty(self) -> None:
+        audio = generate_chime([], duration=0.1)
+        assert len(audio) == 0
+
+    def test_zero_duration_returns_empty(self) -> None:
+        audio = generate_chime([440.0], duration=0.0)
+        assert len(audio) == 0
+
+    def test_volume_clamps_to_zero(self) -> None:
+        audio = generate_chime([440.0], duration=0.1, sample_rate=8000, volume=0.0)
+        assert np.allclose(audio, 0.0)
+
+    def test_volume_above_one_clamped(self) -> None:
+        normal = generate_chime([440.0], duration=0.05, sample_rate=8000, volume=1.0)
+        loud = generate_chime([440.0], duration=0.05, sample_rate=8000, volume=999.0)
+        assert np.allclose(normal, loud)
+
+    def test_single_frequency(self) -> None:
+        audio = generate_chime([1000.0], duration=0.05, sample_rate=8000)
+        assert len(audio) == int(8000 * 0.05)
+
+    def test_amplitude_within_range(self) -> None:
+        audio = generate_chime([440.0, 880.0], duration=0.1, sample_rate=16000)
+        assert float(np.abs(audio).max()) <= 1.0 + 1e-6
+
+
+class TestPlayChimes:
+    @pytest.fixture(autouse=True)
+    def _mock_play(self) -> None:
+        with patch("champi_stt.assistant.audio_feedback._play_nonblocking") as m, \
+             patch("champi_stt.assistant.audio_feedback._device_sample_rate", return_value=44100):
+            self.mock_play = m
+            yield
+
+    @pytest.mark.asyncio
+    async def test_play_chime_start_default(self) -> None:
+        result = await play_chime_start()
+        assert result is True
+        self.mock_play.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_play_chime_start_silent(self) -> None:
+        result = await play_chime_start(theme=FeedbackTheme.SILENT)
+        assert result is True
+        self.mock_play.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_play_chime_end_minimal(self) -> None:
+        result = await play_chime_end(theme=FeedbackTheme.MINIMAL)
+        assert result is True
+        self.mock_play.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_play_chime_wake_default(self) -> None:
+        result = await play_chime_wake()
+        assert result is True
+        self.mock_play.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_play_chime_wake_silent(self) -> None:
+        result = await play_chime_wake(theme=FeedbackTheme.SILENT)
+        assert result is True
+        self.mock_play.assert_not_called()
+
+
+class TestPlayAudioFeedback:
+    @pytest.fixture(autouse=True)
+    def _mock_internals(self) -> None:
+        with patch("champi_stt.assistant.audio_feedback._play_nonblocking"), \
+             patch("champi_stt.assistant.audio_feedback._device_sample_rate", return_value=44100):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_disabled_skips(self) -> None:
+        with patch("champi_stt.assistant.audio_feedback.play_chime_start") as m:
+            await play_audio_feedback("listening", enabled=False)
+            m.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_listening(self) -> None:
+        with patch("champi_stt.assistant.audio_feedback.play_chime_start") as m:
+            await play_audio_feedback("listening")
+            m.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_finished(self) -> None:
+        with patch("champi_stt.assistant.audio_feedback.play_chime_end") as m:
+            await play_audio_feedback("finished")
+            m.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_wake(self) -> None:
+        with patch("champi_stt.assistant.audio_feedback.play_chime_wake") as m:
+            await play_audio_feedback("wake")
+            m.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_unknown_type_does_not_raise(self) -> None:
+        await play_audio_feedback("unknown_type")  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_volume_passed_through(self) -> None:
+        with patch("champi_stt.assistant.audio_feedback.play_chime_wake") as m:
+            await play_audio_feedback("wake", volume=0.5)
+            _, kwargs = m.call_args
+            assert kwargs["volume"] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_theme_passed_through(self) -> None:
+        with patch("champi_stt.assistant.audio_feedback.play_chime_start") as m:
+            await play_audio_feedback("listening", theme=FeedbackTheme.MINIMAL)
+            _, kwargs = m.call_args
+            assert kwargs["theme"] is FeedbackTheme.MINIMAL


### PR DESCRIPTION
## Summary

- Adds `FeedbackTheme` enum (`DEFAULT`, `MINIMAL`, `SILENT`) to `audio_feedback.py`
- Each theme defines distinct frequency sets and tone durations per event type
- `volume` parameter (clamped to [0.0, 1.0]) flows through all public functions
- Playback moved to a daemon thread (`_play_nonblocking`) so the assistant loop is never blocked
- 21 unit tests in `tests/test_audio_feedback.py`

## Test plan

- [ ] `uv run pytest tests/test_audio_feedback.py -v` — 21 passed