### PR TITLE
feat: streaming transcription pipeline (#23)

### DIFF
--- a/src/champi_stt/core/__init__.py
+++ b/src/champi_stt/core/__init__.py
@@ -6,10 +6,14 @@ from champi_stt.core.base_config import BaseSTTConfig
 from champi_stt.core.base_model_manager import BaseModelManager
 from champi_stt.core.base_provider import BaseSTTProvider
 from champi_stt.core.base_transcriber import BaseTranscriber
+from champi_stt.core.response import TranscriptionChunk
+from champi_stt.core.streaming import StreamingTranscriptionConfig
 
 __all__ = [
     "BaseModelManager",
     "BaseSTTConfig",
     "BaseSTTProvider",
     "BaseTranscriber",
+    "StreamingTranscriptionConfig",
+    "TranscriptionChunk",
 ]

--- a/src/champi_stt/core/base_provider.py
+++ b/src/champi_stt/core/base_provider.py
@@ -3,11 +3,13 @@ Base STT provider interface
 """
 
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
 from typing import Any
 
 import numpy as np
 
 from champi_stt.core.base_config import BaseSTTConfig
+from champi_stt.core.response import TranscriptionChunk
 
 
 class BaseSTTProvider(ABC):
@@ -103,6 +105,43 @@ class BaseSTTProvider(ABC):
             task="translate",
             **kwargs,
         )
+
+    async def stream_transcribe(
+        self,
+        audio_source: AsyncIterator[bytes | np.ndarray],
+        language: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[TranscriptionChunk]:
+        """
+        Stream-transcribe audio from an async iterator of audio chunks.
+
+        Default implementation collects all audio, transcribes once, and
+        yields a single final TranscriptionChunk. Providers can override
+        for true incremental/real-time output.
+
+        Args:
+            audio_source: Async iterator of raw bytes or float32 numpy arrays
+            language: Language code hint
+            **kwargs: Provider-specific parameters
+
+        Yields:
+            TranscriptionChunk with partial or final text
+        """
+        chunks: list[np.ndarray] = []
+        async for chunk in audio_source:
+            if isinstance(chunk, bytes):
+                arr: np.ndarray = np.frombuffer(chunk, dtype=np.int16).astype(np.float32) / 32768.0
+            else:
+                arr = chunk
+            chunks.append(arr)
+
+        if not chunks:
+            return
+
+        audio = np.concatenate(chunks)
+        result = await self.transcribe(audio, language=language, **kwargs)
+        text = result if isinstance(result, str) else str(result.get("text", "") if isinstance(result, dict) else result)
+        yield TranscriptionChunk(text=text, is_final=True, language=language or "unknown")
 
     async def detect_language(
         self, audio_data: bytes | np.ndarray | str, **kwargs: Any

--- a/src/champi_stt/core/base_transcriber.py
+++ b/src/champi_stt/core/base_transcriber.py
@@ -4,9 +4,12 @@ Base transcriber interface
 
 import io
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
 from typing import Any
 
 import numpy as np
+
+from champi_stt.core.response import TranscriptionChunk
 
 
 class BaseTranscriber(ABC):
@@ -83,3 +86,40 @@ class BaseTranscriber(ABC):
     async def get_model_info(self) -> dict[str, Any]:
         """Get transcriber/model information"""
         return {"status": "loaded" if self.is_loaded else "not_loaded"}
+
+    async def stream_transcribe(
+        self,
+        audio_source: AsyncIterator[bytes | np.ndarray],
+        language: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[TranscriptionChunk]:
+        """
+        Stream-transcribe audio from an async iterator of audio chunks.
+
+        Default implementation collects all chunks, runs a single transcribe,
+        and yields one final TranscriptionChunk. Providers can override for
+        true incremental output.
+
+        Args:
+            audio_source: Async iterator yielding raw bytes or numpy arrays
+            language: Language code hint
+            **kwargs: Provider-specific parameters
+
+        Yields:
+            TranscriptionChunk with partial or final transcription text
+        """
+        chunks: list[np.ndarray] = []
+        async for chunk in audio_source:
+            if isinstance(chunk, bytes):
+                arr: np.ndarray = np.frombuffer(chunk, dtype=np.int16).astype(np.float32) / 32768.0
+            else:
+                arr = chunk
+            chunks.append(arr)
+
+        if not chunks:
+            return
+
+        audio = np.concatenate(chunks)
+        result = await self.transcribe_audio(audio, language=language, **kwargs)
+        text: str = result.get("text", "") if isinstance(result, dict) else str(result)
+        yield TranscriptionChunk(text=text, is_final=True, language=language or "unknown")

--- a/src/champi_stt/core/response.py
+++ b/src/champi_stt/core/response.py
@@ -41,6 +41,18 @@ class TranscriptionResponse:
 STTResponse = TranscriptionResponse
 
 
+@dataclasses.dataclass
+class TranscriptionChunk:
+    """A partial transcription result produced during real-time streaming."""
+
+    text: str = ""
+    is_final: bool = False
+    confidence: float = 0.0
+    language: str = "unknown"
+    start: float = 0.0
+    end: float = 0.0
+
+
 def format_response(
     result: dict[str, Any], response_format: str
 ) -> str | dict[str, Any]:

--- a/src/champi_stt/core/streaming.py
+++ b/src/champi_stt/core/streaming.py
@@ -1,0 +1,34 @@
+"""Streaming transcription configuration and helpers."""
+
+from __future__ import annotations
+
+import dataclasses
+
+
+@dataclasses.dataclass
+class StreamingTranscriptionConfig:
+    """Configuration for real-time streaming transcription.
+
+    Attributes:
+        chunk_size:        Number of audio frames per chunk sent to the provider.
+        overlap_frames:    Frames of overlap between consecutive chunks for context.
+        vad_aggressiveness: WebRTC VAD mode (0=least, 3=most aggressive).
+        language:          Language hint forwarded to the provider (None = auto).
+        sample_rate:       Audio sample rate in Hz.
+    """
+
+    chunk_size: int = 4096
+    overlap_frames: int = 512
+    vad_aggressiveness: int = 2
+    language: str | None = None
+    sample_rate: int = 16000
+
+    def __post_init__(self) -> None:
+        if self.chunk_size <= 0:
+            raise ValueError("chunk_size must be > 0")
+        if self.overlap_frames < 0:
+            raise ValueError("overlap_frames must be >= 0")
+        if self.vad_aggressiveness not in (0, 1, 2, 3):
+            raise ValueError("vad_aggressiveness must be 0, 1, 2, or 3")
+        if self.sample_rate <= 0:
+            raise ValueError("sample_rate must be > 0")

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,200 @@
+"""Tests for streaming transcription pipeline."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import numpy as np
+import pytest
+
+from champi_stt.core.base_config import BaseSTTConfig
+from champi_stt.core.base_provider import BaseSTTProvider
+from champi_stt.core.base_transcriber import BaseTranscriber
+from champi_stt.core.response import TranscriptionChunk
+from champi_stt.core.streaming import StreamingTranscriptionConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _make_source(*chunks: bytes | np.ndarray) -> AsyncIterator[bytes | np.ndarray]:
+    for c in chunks:
+        yield c
+
+
+class _ConcreteProvider(BaseSTTProvider):
+    def __init__(self) -> None:
+        cfg = MagicMock(spec=BaseSTTConfig)
+        cfg.save_transcriptions = False
+        super().__init__(cfg)
+        self._initialized = True
+
+    async def initialize(self) -> None:
+        self._initialized = True
+
+    async def transcribe(self, audio_data: Any, language: Any = None, **kwargs: Any) -> str:
+        return "hello world"
+
+    async def shutdown(self) -> None:
+        pass
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._initialized
+
+
+class _ConcreteTranscriber(BaseTranscriber):
+    async def initialize(self) -> None:
+        pass
+
+    async def transcribe_audio(self, audio: Any, **kwargs: Any) -> dict[str, Any]:
+        return {"text": "streamed text"}
+
+    async def shutdown(self) -> None:
+        pass
+
+    @property
+    def is_loaded(self) -> bool:
+        return True
+
+
+# ---------------------------------------------------------------------------
+# StreamingTranscriptionConfig
+# ---------------------------------------------------------------------------
+
+class TestStreamingTranscriptionConfig:
+    def test_defaults(self) -> None:
+        cfg = StreamingTranscriptionConfig()
+        assert cfg.chunk_size == 4096
+        assert cfg.overlap_frames == 512
+        assert cfg.vad_aggressiveness == 2
+        assert cfg.language is None
+        assert cfg.sample_rate == 16000
+
+    def test_custom_values(self) -> None:
+        cfg = StreamingTranscriptionConfig(chunk_size=2048, language="es")
+        assert cfg.chunk_size == 2048
+        assert cfg.language == "es"
+
+    def test_invalid_chunk_size(self) -> None:
+        with pytest.raises(ValueError, match="chunk_size"):
+            StreamingTranscriptionConfig(chunk_size=0)
+
+    def test_invalid_overlap(self) -> None:
+        with pytest.raises(ValueError, match="overlap_frames"):
+            StreamingTranscriptionConfig(overlap_frames=-1)
+
+    def test_invalid_vad(self) -> None:
+        with pytest.raises(ValueError, match="vad_aggressiveness"):
+            StreamingTranscriptionConfig(vad_aggressiveness=4)
+
+    def test_invalid_sample_rate(self) -> None:
+        with pytest.raises(ValueError, match="sample_rate"):
+            StreamingTranscriptionConfig(sample_rate=0)
+
+
+# ---------------------------------------------------------------------------
+# TranscriptionChunk
+# ---------------------------------------------------------------------------
+
+class TestTranscriptionChunk:
+    def test_defaults(self) -> None:
+        chunk = TranscriptionChunk()
+        assert chunk.text == ""
+        assert chunk.is_final is False
+        assert chunk.confidence == 0.0
+
+    def test_final_chunk(self) -> None:
+        chunk = TranscriptionChunk(text="done", is_final=True, language="en")
+        assert chunk.is_final is True
+        assert chunk.language == "en"
+
+
+# ---------------------------------------------------------------------------
+# BaseSTTProvider.stream_transcribe (default implementation)
+# ---------------------------------------------------------------------------
+
+class TestBaseProviderStreamTranscribe:
+    @pytest.mark.asyncio
+    async def test_yields_single_final_chunk_from_bytes(self) -> None:
+        provider = _ConcreteProvider()
+        audio_bytes = (np.zeros(1024, dtype=np.int16) * 0).tobytes()
+        source = _make_source(audio_bytes)
+        results = [c async for c in await _collect(provider, source)]
+        assert len(results) == 1
+        assert results[0].is_final is True
+        assert results[0].text == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_yields_single_final_chunk_from_ndarray(self) -> None:
+        provider = _ConcreteProvider()
+        arr = np.zeros(512, dtype=np.float32)
+        source = _make_source(arr)
+        results = [c async for c in await _collect(provider, source)]
+        assert len(results) == 1
+        assert results[0].is_final is True
+
+    @pytest.mark.asyncio
+    async def test_empty_source_yields_nothing(self) -> None:
+        provider = _ConcreteProvider()
+
+        async def empty() -> AsyncIterator[bytes]:
+            return
+            yield  # make it an async generator
+
+        results = [c async for c in await _collect(provider, empty())]
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_multiple_chunks_concatenated(self) -> None:
+        provider = _ConcreteProvider()
+        chunk1 = np.zeros(256, dtype=np.float32)
+        chunk2 = np.zeros(256, dtype=np.float32)
+        source = _make_source(chunk1, chunk2)
+        results = [c async for c in await _collect(provider, source)]
+        assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# BaseTranscriber.stream_transcribe (default implementation)
+# ---------------------------------------------------------------------------
+
+class TestBaseTranscriberStreamTranscribe:
+    @pytest.mark.asyncio
+    async def test_yields_chunk_with_text(self) -> None:
+        transcriber = _ConcreteTranscriber()
+        arr = np.zeros(512, dtype=np.float32)
+        source = _make_source(arr)
+        results = [c async for c in await _collect_t(transcriber, source)]
+        assert len(results) == 1
+        assert results[0].text == "streamed text"
+        assert results[0].is_final is True
+
+    @pytest.mark.asyncio
+    async def test_bytes_chunk_converted(self) -> None:
+        transcriber = _ConcreteTranscriber()
+        raw = np.zeros(512, dtype=np.int16).tobytes()
+        source = _make_source(raw)
+        results = [c async for c in await _collect_t(transcriber, source)]
+        assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# Helpers to drive async generators
+# ---------------------------------------------------------------------------
+
+async def _collect(
+    provider: BaseSTTProvider,
+    source: AsyncIterator[bytes | np.ndarray],
+) -> AsyncIterator[TranscriptionChunk]:
+    return provider.stream_transcribe(source)
+
+
+async def _collect_t(
+    transcriber: BaseTranscriber,
+    source: AsyncIterator[bytes | np.ndarray],
+) -> AsyncIterator[TranscriptionChunk]:
+    return transcriber.stream_transcribe(source)


### PR DESCRIPTION
## Summary

- Adds `TranscriptionChunk` dataclass to `core/response.py` (text, is_final, confidence, language, start, end)
- Adds `StreamingTranscriptionConfig` dataclass to new `core/streaming.py` (chunk_size, overlap_frames, vad_aggressiveness, language, sample_rate) with validation
- Adds default `stream_transcribe()` async generator to both `BaseSTTProvider` and `BaseTranscriber`; providers override for true real-time output
- Exports `StreamingTranscriptionConfig` and `TranscriptionChunk` from `core/__init__.py`
- 14 unit tests in `tests/test_streaming.py`

## Test plan

- [ ] `uv run pytest tests/test_streaming.py -v` — 14 passed