### PR TITLE
feat: speaker diarization via pyannote.audio (#24)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,9 +101,10 @@ webui = [
     "uvicorn>=0.23.0",
 ]
 
-# Speaker diarization / voice identification
+# Speaker diarization via pyannote.audio
 diarization = [
-    "resemblyzer>=0.1.1",
+    "pyannote.audio>=3.1.0",
+    "soundfile>=0.12.0",
 ]
 
 # All optional extras

--- a/src/champi_stt/cli.py
+++ b/src/champi_stt/cli.py
@@ -580,5 +580,40 @@ def service_status(service_type):
     click.echo(status())
 
 
+@cli.command("diarize")
+@click.argument("audio_file", type=click.Path(exists=True))
+@click.option("--hf-token", envvar="HF_TOKEN", default=None, help="HuggingFace access token")
+@click.option("--num-speakers", default=None, type=int, help="Expected number of speakers")
+@click.option("--min-speakers", default=None, type=int, help="Minimum number of speakers")
+@click.option("--max-speakers", default=None, type=int, help="Maximum number of speakers")
+@click.option("--model", default="pyannote/speaker-diarization-3.1", help="pyannote pipeline model")
+def diarize(audio_file, hf_token, num_speakers, min_speakers, max_speakers, model):
+    """Diarize an audio file and print speaker-labelled segments.
+
+    Requires the 'diarization' extra: pip install 'champi-stt[diarization]'
+    A HuggingFace token is needed to download the pyannote model on first run.
+    """
+    from champi_stt.diarization.config import DiarizationConfig
+    from champi_stt.diarization.diarizer import Diarizer
+
+    cfg = DiarizationConfig(
+        hf_token=hf_token,
+        num_speakers=num_speakers,
+        min_speakers=min_speakers,
+        max_speakers=max_speakers,
+        model=model,
+    )
+
+    async def _run() -> None:
+        diarizer = Diarizer(cfg)
+        await diarizer.initialize()
+        segments = await diarizer.diarize(audio_file)
+        for seg in segments:
+            click.echo(f"[{seg.start:.2f}s -> {seg.end:.2f}s] {seg.speaker_id}  {seg.text}")
+        await diarizer.shutdown()
+
+    asyncio.run(_run())
+
+
 if __name__ == "__main__":
     cli()

--- a/src/champi_stt/diarization/__init__.py
+++ b/src/champi_stt/diarization/__init__.py
@@ -1,0 +1,6 @@
+"""Speaker diarization for champi-stt."""
+
+from champi_stt.diarization.config import DiarizationConfig
+from champi_stt.diarization.diarizer import DiarizationSegment, Diarizer
+
+__all__ = ["DiarizationConfig", "DiarizationSegment", "Diarizer"]

--- a/src/champi_stt/diarization/config.py
+++ b/src/champi_stt/diarization/config.py
@@ -1,0 +1,32 @@
+"""Diarization configuration."""
+
+from __future__ import annotations
+
+import dataclasses
+
+
+@dataclasses.dataclass
+class DiarizationConfig:
+    """Configuration for speaker diarization.
+
+    Attributes:
+        hf_token:          HuggingFace access token for pyannote models.
+        num_speakers:      Expected number of speakers (None = auto-detect).
+        min_speakers:      Minimum number of speakers when auto-detecting.
+        max_speakers:      Maximum number of speakers when auto-detecting.
+        model:             pyannote pipeline model identifier.
+        device:            Compute device ("cpu", "cuda", "mps").
+    """
+
+    hf_token: str | None = None
+    num_speakers: int | None = None
+    min_speakers: int | None = None
+    max_speakers: int | None = None
+    model: str = "pyannote/speaker-diarization-3.1"
+    device: str = "cpu"
+
+    @classmethod
+    def from_env(cls) -> "DiarizationConfig":
+        import os
+
+        return cls(hf_token=os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_TOKEN"))

--- a/src/champi_stt/diarization/diarizer.py
+++ b/src/champi_stt/diarization/diarizer.py
@@ -1,0 +1,167 @@
+"""Speaker diarization via pyannote.audio."""
+
+from __future__ import annotations
+
+import dataclasses
+import io
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from loguru import logger
+
+try:
+    from pyannote.audio import Pipeline  # type: ignore[import-untyped]
+
+    PYANNOTE_AVAILABLE = True
+except ImportError:
+    PYANNOTE_AVAILABLE = False
+
+    class Pipeline:  # type: ignore[no-redef]
+        pass
+
+
+from champi_stt.diarization.config import DiarizationConfig
+
+
+@dataclasses.dataclass
+class DiarizationSegment:
+    """A time-stamped segment attributed to a speaker.
+
+    Attributes:
+        speaker_id: Speaker label (e.g. "SPEAKER_00").
+        start:      Segment start time in seconds.
+        end:        Segment end time in seconds.
+        text:       Transcription text for this segment (empty until annotated).
+    """
+
+    speaker_id: str
+    start: float
+    end: float
+    text: str = ""
+
+
+class Diarizer:
+    """Wraps a pyannote.audio pipeline to label audio with speaker segments."""
+
+    def __init__(self, config: DiarizationConfig | None = None) -> None:
+        self.config = config or DiarizationConfig()
+        self._pipeline: Pipeline | None = None
+
+    async def initialize(self) -> None:
+        """Load the pyannote diarization pipeline."""
+        if not PYANNOTE_AVAILABLE:
+            raise ImportError(
+                "pyannote.audio is required for diarization. "
+                "Install with: pip install 'champi-stt[diarization]'"
+            )
+        import asyncio
+
+        def _load() -> Pipeline:
+            kwargs: dict[str, Any] = {}
+            if self.config.hf_token:
+                kwargs["use_auth_token"] = self.config.hf_token
+            return Pipeline.from_pretrained(self.config.model, **kwargs)
+
+        self._pipeline = await asyncio.get_running_loop().run_in_executor(None, _load)
+        logger.info(f"Diarization pipeline loaded: {self.config.model}")
+
+    async def diarize(
+        self,
+        audio: np.ndarray | bytes | str | Path,
+        sample_rate: int = 16000,
+    ) -> list[DiarizationSegment]:
+        """Run diarization on audio and return speaker-labelled segments.
+
+        Args:
+            audio:       Audio as numpy array (float32), raw bytes (int16 PCM),
+                         or a file path.
+            sample_rate: Sample rate of the audio in Hz.
+
+        Returns:
+            List of DiarizationSegment sorted by start time.
+        """
+        if self._pipeline is None:
+            raise RuntimeError("Call initialize() before diarize()")
+
+        import asyncio
+
+        audio_path = await asyncio.get_running_loop().run_in_executor(
+            None, lambda: self._to_wav_path(audio, sample_rate)
+        )
+
+        diarize_kwargs: dict[str, Any] = {}
+        if self.config.num_speakers is not None:
+            diarize_kwargs["num_speakers"] = self.config.num_speakers
+        else:
+            if self.config.min_speakers is not None:
+                diarize_kwargs["min_speakers"] = self.config.min_speakers
+            if self.config.max_speakers is not None:
+                diarize_kwargs["max_speakers"] = self.config.max_speakers
+
+        def _run() -> Any:
+            return self._pipeline(audio_path, **diarize_kwargs)
+
+        annotation = await asyncio.get_running_loop().run_in_executor(None, _run)
+
+        segments: list[DiarizationSegment] = []
+        for turn, _, speaker in annotation.itertracks(yield_label=True):
+            segments.append(
+                DiarizationSegment(
+                    speaker_id=speaker,
+                    start=round(turn.start, 3),
+                    end=round(turn.end, 3),
+                )
+            )
+
+        return sorted(segments, key=lambda s: s.start)
+
+    def annotate_transcription(
+        self,
+        segments: list[DiarizationSegment],
+        text: str,
+    ) -> list[DiarizationSegment]:
+        """Attach transcription text to the closest diarization segment.
+
+        This is a simple heuristic: split text by sentence-ending punctuation
+        and assign each part to the next available segment in order.
+
+        Args:
+            segments: Diarization segments from diarize().
+            text:     Full transcription text.
+
+        Returns:
+            Segments with the text field populated.
+        """
+        import re
+
+        parts = [p.strip() for p in re.split(r"(?<=[.!?])\s+", text) if p.strip()]
+        for i, part in enumerate(parts):
+            if i < len(segments):
+                segments[i].text = part
+        return segments
+
+    @staticmethod
+    def _to_wav_path(
+        audio: np.ndarray | bytes | str | Path,
+        sample_rate: int,
+    ) -> str:
+        """Convert audio to a temporary WAV file and return its path."""
+        if isinstance(audio, (str, Path)):
+            return str(audio)
+
+        import soundfile as sf  # type: ignore[import-untyped]
+
+        if isinstance(audio, bytes):
+            arr: np.ndarray = np.frombuffer(audio, dtype=np.int16).astype(np.float32) / 32768.0
+        else:
+            arr = audio
+
+        tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        sf.write(tmp.name, arr, sample_rate)
+        return tmp.name
+
+    async def shutdown(self) -> None:
+        """Release the pipeline."""
+        self._pipeline = None

--- a/tests/test_diarization.py
+++ b/tests/test_diarization.py
@@ -1,0 +1,136 @@
+"""Tests for speaker diarization module."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
+from champi_stt.diarization.config import DiarizationConfig
+from champi_stt.diarization.diarizer import DiarizationSegment, Diarizer
+
+
+class TestDiarizationConfig:
+    def test_defaults(self) -> None:
+        cfg = DiarizationConfig()
+        assert cfg.hf_token is None
+        assert cfg.num_speakers is None
+        assert cfg.model == "pyannote/speaker-diarization-3.1"
+        assert cfg.device == "cpu"
+
+    def test_from_env_hf_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HF_TOKEN", "tok123")
+        cfg = DiarizationConfig.from_env()
+        assert cfg.hf_token == "tok123"
+
+    def test_from_env_huggingface_token_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setenv("HUGGINGFACE_TOKEN", "tok456")
+        cfg = DiarizationConfig.from_env()
+        assert cfg.hf_token == "tok456"
+
+    def test_from_env_no_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.delenv("HUGGINGFACE_TOKEN", raising=False)
+        cfg = DiarizationConfig.from_env()
+        assert cfg.hf_token is None
+
+
+class TestDiarizationSegment:
+    def test_fields(self) -> None:
+        seg = DiarizationSegment(speaker_id="SPEAKER_00", start=0.5, end=2.0, text="hello")
+        assert seg.speaker_id == "SPEAKER_00"
+        assert seg.start == 0.5
+        assert seg.end == 2.0
+        assert seg.text == "hello"
+
+    def test_default_text(self) -> None:
+        seg = DiarizationSegment(speaker_id="SPEAKER_01", start=0.0, end=1.0)
+        assert seg.text == ""
+
+
+class TestDiarizer:
+    def test_init_default_config(self) -> None:
+        d = Diarizer()
+        assert d.config.model == "pyannote/speaker-diarization-3.1"
+
+    @pytest.mark.asyncio
+    async def test_initialize_raises_without_pyannote(self) -> None:
+        with patch("champi_stt.diarization.diarizer.PYANNOTE_AVAILABLE", False):
+            d = Diarizer()
+            with pytest.raises(ImportError, match="pyannote"):
+                await d.initialize()
+
+    @pytest.mark.asyncio
+    async def test_diarize_raises_before_initialize(self) -> None:
+        d = Diarizer()
+        with pytest.raises(RuntimeError, match="initialize"):
+            await d.diarize(np.zeros(1024, dtype=np.float32))
+
+    @pytest.mark.asyncio
+    async def test_diarize_with_mock_pipeline(self, tmp_path: Path) -> None:
+        mock_turn1 = MagicMock()
+        mock_turn1.start = 0.0
+        mock_turn1.end = 1.5
+        mock_turn2 = MagicMock()
+        mock_turn2.start = 1.5
+        mock_turn2.end = 3.0
+
+        mock_annotation = MagicMock()
+        mock_annotation.itertracks.return_value = [
+            (mock_turn1, None, "SPEAKER_00"),
+            (mock_turn2, None, "SPEAKER_01"),
+        ]
+
+        mock_pipeline = MagicMock(return_value=mock_annotation)
+        mock_pipeline_cls = MagicMock()
+        mock_pipeline_cls.from_pretrained.return_value = mock_pipeline
+
+        with patch("champi_stt.diarization.diarizer.PYANNOTE_AVAILABLE", True), \
+             patch("champi_stt.diarization.diarizer.Pipeline", mock_pipeline_cls), \
+             patch("champi_stt.diarization.diarizer.Diarizer._to_wav_path", return_value="/tmp/x.wav"):
+            d = Diarizer(DiarizationConfig(hf_token="tok"))
+            await d.initialize()
+            audio = np.zeros(16000, dtype=np.float32)
+            segments = await d.diarize(audio)
+
+        assert len(segments) == 2
+        assert segments[0].speaker_id == "SPEAKER_00"
+        assert segments[1].speaker_id == "SPEAKER_01"
+
+    @pytest.mark.asyncio
+    async def test_shutdown_clears_pipeline(self) -> None:
+        d = Diarizer()
+        d._pipeline = MagicMock()
+        await d.shutdown()
+        assert d._pipeline is None
+
+    def test_annotate_transcription(self) -> None:
+        segs = [
+            DiarizationSegment("SPEAKER_00", 0.0, 1.0),
+            DiarizationSegment("SPEAKER_01", 1.0, 2.0),
+        ]
+        result = Diarizer().annotate_transcription(segs, "Hello world. How are you?")
+        assert result[0].text == "Hello world."
+        assert result[1].text == "How are you?"
+
+    def test_annotate_fewer_parts_than_segments(self) -> None:
+        segs = [
+            DiarizationSegment("SPEAKER_00", 0.0, 1.0),
+            DiarizationSegment("SPEAKER_01", 1.0, 2.0),
+        ]
+        result = Diarizer().annotate_transcription(segs, "Only one sentence.")
+        assert result[0].text == "Only one sentence."
+        assert result[1].text == ""
+
+    def test_to_wav_path_string(self) -> None:
+        path = Diarizer._to_wav_path("/some/file.wav", 16000)
+        assert path == "/some/file.wav"
+
+    def test_to_wav_path_pathlib(self, tmp_path: Path) -> None:
+        p = tmp_path / "audio.wav"
+        result = Diarizer._to_wav_path(p, 16000)
+        assert result == str(p)


### PR DESCRIPTION
## Summary

- Adds `src/champi_stt/diarization/` package with `DiarizationConfig`, `DiarizationSegment`, and `Diarizer`
- `Diarizer.diarize()` wraps pyannote.audio Pipeline, runs async, returns speaker-labelled segments sorted by start time
- `Diarizer.annotate_transcription()` attaches transcription text to segments by sentence splitting
- Updates `diarization` optional extra from `resemblyzer` to `pyannote.audio>=3.1.0` + `soundfile`
- Adds `champi-stt diarize <audio_file>` CLI command with `--hf-token`, `--num-speakers`, `--min-speakers`, `--max-speakers`, `--model` options
- 15 unit tests in `tests/test_diarization.py`

## Test plan

- [ ] `uv run pytest tests/test_diarization.py -v` — 15 passed
- [ ] `champi-stt diarize --help` shows the command