### PR TITLE
feat: multi-room audio manager (#25)

### DIFF
--- a/src/champi_stt/core/__init__.py
+++ b/src/champi_stt/core/__init__.py
@@ -6,6 +6,7 @@ from champi_stt.core.base_config import BaseSTTConfig
 from champi_stt.core.base_model_manager import BaseModelManager
 from champi_stt.core.base_provider import BaseSTTProvider
 from champi_stt.core.base_transcriber import BaseTranscriber
+from champi_stt.core.multi_room import MultiRoomAudioManager, RoomAudioChunk, RoomConfig
 from champi_stt.core.response import TranscriptionChunk
 from champi_stt.core.streaming import StreamingTranscriptionConfig
 
@@ -14,6 +15,9 @@ __all__ = [
     "BaseSTTConfig",
     "BaseSTTProvider",
     "BaseTranscriber",
+    "MultiRoomAudioManager",
+    "RoomAudioChunk",
+    "RoomConfig",
     "StreamingTranscriptionConfig",
     "TranscriptionChunk",
 ]

--- a/src/champi_stt/core/multi_room.py
+++ b/src/champi_stt/core/multi_room.py
@@ -1,0 +1,172 @@
+"""Multi-room audio: manage multiple simultaneous input device streams."""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import queue
+import threading
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+
+import numpy as np
+from loguru import logger
+
+try:
+    import sounddevice as sd  # type: ignore[import-untyped]
+
+    SOUNDDEVICE_AVAILABLE = True
+except (ImportError, OSError):
+    SOUNDDEVICE_AVAILABLE = False
+    sd = None  # type: ignore[assignment]
+
+
+@dataclasses.dataclass
+class RoomConfig:
+    """Configuration for a single audio input room.
+
+    Attributes:
+        name:        Unique room identifier (e.g. "living_room").
+        device:      sounddevice device index or name (None = system default).
+        sample_rate: Audio sample rate in Hz.
+        channels:    Number of input channels.
+        chunk_size:  Frames per callback.
+    """
+
+    name: str
+    device: int | str | None = None
+    sample_rate: int = 16000
+    channels: int = 1
+    chunk_size: int = 4096
+
+
+@dataclasses.dataclass
+class RoomAudioChunk:
+    """An audio chunk tagged with its room of origin.
+
+    Attributes:
+        room:  Room name from RoomConfig.name.
+        audio: Float32 numpy array of shape (frames, channels) or (frames,).
+    """
+
+    room: str
+    audio: np.ndarray
+
+
+AudioCallback = Callable[[RoomAudioChunk], None]
+
+
+class RoomStream:
+    """Manages a single sounddevice InputStream for one room."""
+
+    def __init__(self, config: RoomConfig, on_chunk: AudioCallback) -> None:
+        self.config = config
+        self._on_chunk = on_chunk
+        self._stream: Any = None
+
+    def start(self) -> None:
+        if not SOUNDDEVICE_AVAILABLE:
+            raise ImportError("sounddevice is required for multi-room audio")
+
+        def _callback(
+            indata: np.ndarray, frames: int, time: Any, status: Any
+        ) -> None:
+            if status:
+                logger.warning(f"[{self.config.name}] audio callback status: {status}")
+            audio: np.ndarray = indata.copy()
+            self._on_chunk(RoomAudioChunk(room=self.config.name, audio=audio))
+
+        self._stream = sd.InputStream(
+            device=self.config.device,
+            samplerate=self.config.sample_rate,
+            channels=self.config.channels,
+            blocksize=self.config.chunk_size,
+            dtype="float32",
+            callback=_callback,
+        )
+        self._stream.start()
+        logger.info(f"Room '{self.config.name}' stream started (device={self.config.device})")
+
+    def stop(self) -> None:
+        if self._stream is not None:
+            self._stream.stop()
+            self._stream.close()
+            self._stream = None
+        logger.info(f"Room '{self.config.name}' stream stopped")
+
+    @property
+    def is_active(self) -> bool:
+        return self._stream is not None and self._stream.active
+
+
+class MultiRoomAudioManager:
+    """Manages multiple simultaneous input device streams across rooms.
+
+    Usage::
+
+        manager = MultiRoomAudioManager([
+            RoomConfig("living_room", device=0),
+            RoomConfig("kitchen", device=1),
+        ])
+        await manager.start()
+        async for chunk in manager.stream():
+            print(chunk.room, chunk.audio.shape)
+        await manager.stop()
+    """
+
+    def __init__(self, rooms: list[RoomConfig]) -> None:
+        self._rooms = rooms
+        self._streams: dict[str, RoomStream] = {}
+        self._queue: queue.Queue[RoomAudioChunk] = queue.Queue()
+        self._running = False
+
+    async def start(self) -> None:
+        """Start all room streams."""
+        if self._running:
+            return
+        self._running = True
+        for cfg in self._rooms:
+            stream = RoomStream(cfg, on_chunk=self._queue.put)
+            stream.start()
+            self._streams[cfg.name] = stream
+
+    async def stop(self) -> None:
+        """Stop all room streams."""
+        self._running = False
+        for stream in self._streams.values():
+            stream.stop()
+        self._streams.clear()
+
+    async def stream(self) -> AsyncIterator[RoomAudioChunk]:
+        """Yield audio chunks from all rooms as they arrive."""
+        loop = asyncio.get_running_loop()
+        while self._running:
+            try:
+                chunk = await loop.run_in_executor(
+                    None, lambda: self._queue.get(timeout=0.1)
+                )
+                yield chunk
+            except queue.Empty:
+                continue
+
+    def active_rooms(self) -> list[str]:
+        """Return names of currently active rooms."""
+        return [name for name, s in self._streams.items() if s.is_active]
+
+    def add_room(self, config: RoomConfig) -> None:
+        """Add and start a new room stream at runtime."""
+        if any(r.name == config.name for r in self._rooms):
+            logger.warning(f"Room '{config.name}' already exists — skipping")
+            return
+        stream = RoomStream(config, on_chunk=self._queue.put)
+        if self._running:
+            stream.start()
+        self._streams[config.name] = stream
+        self._rooms.append(config)
+
+    def remove_room(self, name: str) -> None:
+        """Stop and remove a room stream by name."""
+        stream = self._streams.pop(name, None)
+        if stream:
+            stream.stop()
+        self._rooms = [r for r in self._rooms if r.name != name]

--- a/tests/test_multi_room.py
+++ b/tests/test_multi_room.py
@@ -1,0 +1,173 @@
+"""Tests for multi-room audio manager."""
+
+from __future__ import annotations
+
+import asyncio
+import queue
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from champi_stt.core.multi_room import (
+    MultiRoomAudioManager,
+    RoomAudioChunk,
+    RoomConfig,
+    RoomStream,
+)
+
+
+class TestRoomConfig:
+    def test_defaults(self) -> None:
+        cfg = RoomConfig(name="living_room")
+        assert cfg.device is None
+        assert cfg.sample_rate == 16000
+        assert cfg.channels == 1
+        assert cfg.chunk_size == 4096
+
+    def test_custom(self) -> None:
+        cfg = RoomConfig(name="kitchen", device=1, sample_rate=44100)
+        assert cfg.device == 1
+        assert cfg.sample_rate == 44100
+
+
+class TestRoomAudioChunk:
+    def test_fields(self) -> None:
+        audio = np.zeros(512, dtype=np.float32)
+        chunk = RoomAudioChunk(room="kitchen", audio=audio)
+        assert chunk.room == "kitchen"
+        assert chunk.audio.shape == (512,)
+
+
+class TestRoomStream:
+    def test_start_raises_without_sounddevice(self) -> None:
+        with patch("champi_stt.core.multi_room.SOUNDDEVICE_AVAILABLE", False):
+            stream = RoomStream(RoomConfig("r"), on_chunk=lambda c: None)
+            with pytest.raises(ImportError, match="sounddevice"):
+                stream.start()
+
+    def test_start_stop(self) -> None:
+        mock_sd_stream = MagicMock()
+        mock_sd_stream.active = True
+        mock_sd = MagicMock()
+        mock_sd.InputStream.return_value = mock_sd_stream
+
+        with patch("champi_stt.core.multi_room.SOUNDDEVICE_AVAILABLE", True), \
+             patch("champi_stt.core.multi_room.sd", mock_sd):
+            stream = RoomStream(RoomConfig("room1", device=0), on_chunk=lambda c: None)
+            stream.start()
+            assert stream.is_active
+            stream.stop()
+            mock_sd_stream.stop.assert_called_once()
+            mock_sd_stream.close.assert_called_once()
+
+    def test_stop_when_not_started(self) -> None:
+        stream = RoomStream(RoomConfig("r"), on_chunk=lambda c: None)
+        stream.stop()  # should not raise
+
+    def test_callback_invoked(self) -> None:
+        received: list[RoomAudioChunk] = []
+
+        mock_sd_stream = MagicMock()
+        mock_sd_stream.active = True
+        captured_callback: list = []
+
+        def fake_input_stream(**kwargs):
+            captured_callback.append(kwargs["callback"])
+            return mock_sd_stream
+
+        mock_sd = MagicMock()
+        mock_sd.InputStream.side_effect = fake_input_stream
+        with patch("champi_stt.core.multi_room.SOUNDDEVICE_AVAILABLE", True), \
+             patch("champi_stt.core.multi_room.sd", mock_sd):
+            stream = RoomStream(RoomConfig("r"), on_chunk=received.append)
+            stream.start()
+
+        indata = np.ones((512, 1), dtype=np.float32)
+        captured_callback[0](indata, 512, None, None)
+        assert len(received) == 1
+        assert received[0].room == "r"
+
+
+class TestMultiRoomAudioManager:
+    def _make_mock_streams(self, *names: str):
+        """Patch RoomStream.start/stop so no real audio device is needed."""
+        mock_streams: dict[str, MagicMock] = {}
+
+        original_init = RoomStream.__init__
+
+        def fake_start(self_stream) -> None:
+            self_stream._stream = MagicMock()
+            self_stream._stream.active = True
+
+        def fake_stop(self_stream) -> None:
+            self_stream._stream = None
+
+        return patch.multiple(RoomStream, start=fake_start, stop=fake_stop)
+
+    @pytest.mark.asyncio
+    async def test_start_creates_streams(self) -> None:
+        rooms = [RoomConfig("a"), RoomConfig("b")]
+        mgr = MultiRoomAudioManager(rooms)
+        with patch.object(RoomStream, "start"), patch.object(RoomStream, "stop"):
+            await mgr.start()
+            assert set(mgr._streams.keys()) == {"a", "b"}
+            await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_double_start_is_idempotent(self) -> None:
+        mgr = MultiRoomAudioManager([RoomConfig("a")])
+        with patch.object(RoomStream, "start") as mock_start, \
+             patch.object(RoomStream, "stop"):
+            await mgr.start()
+            await mgr.start()
+            assert mock_start.call_count == 1
+            await mgr.stop()
+
+    @pytest.mark.asyncio
+    async def test_stream_yields_chunks(self) -> None:
+        mgr = MultiRoomAudioManager([RoomConfig("a")])
+        audio = np.zeros(512, dtype=np.float32)
+        mgr._queue.put(RoomAudioChunk(room="a", audio=audio))
+        mgr._running = True
+
+        chunks = []
+        async for chunk in mgr.stream():
+            chunks.append(chunk)
+            mgr._running = False
+
+        assert len(chunks) == 1
+        assert chunks[0].room == "a"
+
+    @pytest.mark.asyncio
+    async def test_active_rooms(self) -> None:
+        mgr = MultiRoomAudioManager([])
+        mock_stream = MagicMock()
+        mock_stream.is_active = True
+        mgr._streams["living"] = mock_stream
+        assert mgr.active_rooms() == ["living"]
+
+    def test_add_room_when_not_running(self) -> None:
+        mgr = MultiRoomAudioManager([])
+        with patch.object(RoomStream, "start") as mock_start:
+            mgr.add_room(RoomConfig("new"))
+            mock_start.assert_not_called()
+        assert "new" in mgr._streams
+
+    def test_add_room_duplicate_skipped(self) -> None:
+        mgr = MultiRoomAudioManager([RoomConfig("dup")])
+        with patch.object(RoomStream, "start"):
+            mgr.add_room(RoomConfig("dup"))
+        assert len([r for r in mgr._rooms if r.name == "dup"]) == 1
+
+    def test_remove_room(self) -> None:
+        mgr = MultiRoomAudioManager([RoomConfig("x")])
+        mock_stream = MagicMock()
+        mgr._streams["x"] = mock_stream
+        mgr.remove_room("x")
+        mock_stream.stop.assert_called_once()
+        assert "x" not in mgr._streams
+
+    def test_remove_nonexistent_room(self) -> None:
+        mgr = MultiRoomAudioManager([])
+        mgr.remove_room("ghost")  # should not raise


### PR DESCRIPTION
## Summary

- Adds `core/multi_room.py` with `RoomConfig`, `RoomAudioChunk`, `RoomStream`, and `MultiRoomAudioManager`
- `MultiRoomAudioManager.stream()` is an async generator yielding `RoomAudioChunk` from all active rooms concurrently
- `add_room()` / `remove_room()` allow runtime pool changes without restarting the manager
- Exports from `core/__init__.py`
- 15 unit tests in `tests/test_multi_room.py` (no real audio hardware required)

## Test plan

- [ ] `uv run pytest tests/test_multi_room.py -v` — 15 passed