### PR TITLE
feat: REST API server for external integration (#26)

### DIFF
--- a/src/champi_stt/api/__init__.py
+++ b/src/champi_stt/api/__init__.py
@@ -1,0 +1,5 @@
+"""REST API server for champi-stt external integrations."""
+
+from champi_stt.api.server import create_api_app, serve_api
+
+__all__ = ["create_api_app", "serve_api"]

--- a/src/champi_stt/api/server.py
+++ b/src/champi_stt/api/server.py
@@ -1,0 +1,167 @@
+"""
+REST API server for champi-stt.
+
+Exposes:
+  POST /transcribe      — Upload an audio file, returns transcription text
+  GET  /status          — Service health and loaded provider info
+  POST /command         — Inject a text command into the assistant pipeline
+  WS   /stream          — WebSocket for real-time transcript streaming
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+
+from loguru import logger
+
+try:
+    from fastapi import FastAPI, HTTPException, UploadFile, WebSocket, WebSocketDisconnect
+    from fastapi.responses import JSONResponse
+    import uvicorn
+
+    FASTAPI_AVAILABLE = True
+except ImportError:
+    FASTAPI_AVAILABLE = False
+
+_DEFAULT_HOST = "localhost"
+_DEFAULT_PORT = 8766
+
+_provider: Any = None
+_command_queue: asyncio.Queue[str] | None = None
+
+
+def _require_fastapi() -> None:
+    if not FASTAPI_AVAILABLE:
+        raise ImportError(
+            "fastapi and uvicorn are required for the REST API. "
+            "Install with: pip install 'champi-stt[webui]'"
+        )
+
+
+def create_api_app(
+    provider: Any | None = None,
+    command_queue: asyncio.Queue[str] | None = None,
+) -> "FastAPI":
+    """Build the FastAPI REST application.
+
+    Args:
+        provider:       An initialized BaseSTTProvider used for /transcribe and /stream.
+        command_queue:  asyncio.Queue that receives injected text commands from POST /command.
+
+    Returns:
+        Configured FastAPI application.
+    """
+    _require_fastapi()
+
+    app = FastAPI(title="Champi STT API", version="1.0", docs_url="/docs", redoc_url=None)
+    _state: dict[str, Any] = {"provider": provider, "command_queue": command_queue}
+
+    @app.get("/status")
+    async def status() -> JSONResponse:
+        prov = _state["provider"]
+        return JSONResponse(
+            {
+                "status": "ok",
+                "provider": prov.__class__.__name__ if prov else None,
+                "ready": bool(prov and getattr(prov, "is_loaded", False)),
+            }
+        )
+
+    @app.post("/transcribe")
+    async def transcribe(file: UploadFile) -> JSONResponse:
+        prov = _state["provider"]
+        if prov is None:
+            raise HTTPException(status_code=503, detail="No provider configured")
+
+        try:
+            audio_bytes = await file.read()
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=f"Could not read upload: {exc}") from exc
+
+        t0 = time.monotonic()
+        try:
+            result = await prov.transcribe(audio_bytes)
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+        elapsed = round(time.monotonic() - t0, 3)
+        text = result if isinstance(result, str) else result.get("text", "") if isinstance(result, dict) else str(result)
+        return JSONResponse({"text": text, "processing_time": elapsed})
+
+    @app.post("/command")
+    async def inject_command(payload: dict[str, Any]) -> JSONResponse:
+        text = payload.get("text", "").strip()
+        if not text:
+            raise HTTPException(status_code=400, detail="'text' field is required and must not be empty")
+
+        q = _state["command_queue"]
+        if q is None:
+            raise HTTPException(status_code=503, detail="Command queue not configured")
+
+        await q.put(text)
+        logger.info(f"Command injected via API: {text!r}")
+        return JSONResponse({"status": "queued", "text": text})
+
+    @app.websocket("/stream")
+    async def stream(websocket: WebSocket) -> None:
+        await websocket.accept()
+        prov = _state["provider"]
+        if prov is None:
+            await websocket.send_json({"error": "No provider configured"})
+            await websocket.close(code=1011)
+            return
+
+        try:
+            async def _audio_source() -> AsyncIterator[bytes]:
+                while True:
+                    try:
+                        data = await asyncio.wait_for(websocket.receive_bytes(), timeout=30.0)
+                        if data == b"__END__":
+                            break
+                        yield data
+                    except asyncio.TimeoutError:
+                        break
+
+            if hasattr(prov, "stream_transcribe"):
+                async for chunk in prov.stream_transcribe(_audio_source()):
+                    await websocket.send_json(
+                        {
+                            "text": chunk.text,
+                            "is_final": chunk.is_final,
+                            "language": chunk.language,
+                        }
+                    )
+            else:
+                await websocket.send_json({"error": "Provider does not support streaming"})
+
+        except WebSocketDisconnect:
+            logger.info("WebSocket client disconnected")
+        except Exception as exc:
+            logger.warning(f"WebSocket error: {exc}")
+            await websocket.close(code=1011)
+
+    return app
+
+
+def serve_api(
+    provider: Any | None = None,
+    command_queue: asyncio.Queue[str] | None = None,
+    host: str = _DEFAULT_HOST,
+    port: int = _DEFAULT_PORT,
+) -> None:
+    """Start the REST API server (blocking).
+
+    Args:
+        provider:       STT provider for transcription endpoints.
+        command_queue:  Queue for POST /command injections.
+        host:           Bind address (default: localhost).
+        port:           Port to listen on (default: 8766).
+    """
+    _require_fastapi()
+    app = create_api_app(provider=provider, command_queue=command_queue)
+    logger.info(f"Starting REST API at http://{host}:{port}")
+    uvicorn.run(app, host=host, port=port, log_level="warning")

--- a/src/champi_stt/cli.py
+++ b/src/champi_stt/cli.py
@@ -580,6 +580,21 @@ def service_status(service_type):
     click.echo(status())
 
 
+@cli.command("serve")
+@click.option("--provider", default="whisperlive", help="STT provider to load")
+@click.option("--host", default="localhost", show_default=True, help="Bind address")
+@click.option("--port", default=8766, show_default=True, type=int, help="Port to listen on")
+def serve_api(provider, host, port):
+    """Start the REST API server.
+
+    Exposes POST /transcribe, GET /status, POST /command, and WS /stream.
+    Requires the 'webui' extra: pip install 'champi-stt[webui]'
+    """
+    from champi_stt.api.server import serve_api as _serve
+
+    _serve(host=host, port=port)
+
+
 @cli.command("diarize")
 @click.argument("audio_file", type=click.Path(exists=True))
 @click.option("--hf-token", envvar="HF_TOKEN", default=None, help="HuggingFace access token")

--- a/tests/test_api_server.py
+++ b/tests/test_api_server.py
@@ -1,0 +1,143 @@
+"""Tests for the REST API server."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_provider():
+    prov = MagicMock()
+    prov.__class__.__name__ = "MockProvider"
+    prov.is_loaded = True
+    prov.transcribe = AsyncMock(return_value="hello world")
+    return prov
+
+
+class TestCreateApiApp:
+    def test_raises_without_fastapi(self) -> None:
+        with patch("champi_stt.api.server.FASTAPI_AVAILABLE", False):
+            from champi_stt.api.server import create_api_app
+
+            with pytest.raises(ImportError, match="fastapi"):
+                create_api_app()
+
+    def test_status_no_provider(self) -> None:
+        pytest.importorskip("fastapi")
+        from fastapi.testclient import TestClient
+        from champi_stt.api.server import create_api_app
+
+        client = TestClient(create_api_app())
+        r = client.get("/status")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["status"] == "ok"
+        assert data["provider"] is None
+        assert data["ready"] is False
+
+    def test_status_with_provider(self, mock_provider) -> None:
+        pytest.importorskip("fastapi")
+        from fastapi.testclient import TestClient
+        from champi_stt.api.server import create_api_app
+
+        client = TestClient(create_api_app(provider=mock_provider))
+        r = client.get("/status")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["ready"] is True
+        assert data["provider"] == "MockProvider"
+
+    def test_transcribe_no_provider(self) -> None:
+        pytest.importorskip("fastapi")
+        from fastapi.testclient import TestClient
+        from champi_stt.api.server import create_api_app
+
+        client = TestClient(create_api_app())
+        r = client.post("/transcribe", files={"file": ("audio.wav", b"\x00" * 100, "audio/wav")})
+        assert r.status_code == 503
+
+    def test_transcribe_with_provider(self, mock_provider) -> None:
+        pytest.importorskip("fastapi")
+        from fastapi.testclient import TestClient
+        from champi_stt.api.server import create_api_app
+
+        client = TestClient(create_api_app(provider=mock_provider))
+        r = client.post("/transcribe", files={"file": ("audio.wav", b"\x00" * 100, "audio/wav")})
+        assert r.status_code == 200
+        data = r.json()
+        assert data["text"] == "hello world"
+        assert "processing_time" in data
+
+    def test_transcribe_provider_error(self, mock_provider) -> None:
+        pytest.importorskip("fastapi")
+        from fastapi.testclient import TestClient
+        from champi_stt.api.server import create_api_app
+
+        mock_provider.transcribe.side_effect = RuntimeError("model exploded")
+        client = TestClient(create_api_app(provider=mock_provider))
+        r = client.post("/transcribe", files={"file": ("a.wav", b"\x00" * 10, "audio/wav")})
+        assert r.status_code == 500
+
+    def test_command_no_queue(self) -> None:
+        pytest.importorskip("fastapi")
+        from fastapi.testclient import TestClient
+        from champi_stt.api.server import create_api_app
+
+        client = TestClient(create_api_app())
+        r = client.post("/command", json={"text": "play music"})
+        assert r.status_code == 503
+
+    def test_command_queued(self) -> None:
+        pytest.importorskip("fastapi")
+        from fastapi.testclient import TestClient
+        from champi_stt.api.server import create_api_app
+
+        q: asyncio.Queue[str] = asyncio.Queue()
+        client = TestClient(create_api_app(command_queue=q))
+        r = client.post("/command", json={"text": "play music"})
+        assert r.status_code == 200
+        assert r.json()["status"] == "queued"
+        assert not q.empty()
+
+    def test_command_empty_text(self) -> None:
+        pytest.importorskip("fastapi")
+        from fastapi.testclient import TestClient
+        from champi_stt.api.server import create_api_app
+
+        q: asyncio.Queue[str] = asyncio.Queue()
+        client = TestClient(create_api_app(command_queue=q))
+        r = client.post("/command", json={"text": "  "})
+        assert r.status_code == 400
+
+    def test_docs_endpoint_available(self) -> None:
+        pytest.importorskip("fastapi")
+        from fastapi.testclient import TestClient
+        from champi_stt.api.server import create_api_app
+
+        client = TestClient(create_api_app())
+        r = client.get("/docs")
+        assert r.status_code == 200
+
+
+class TestServeApi:
+    def test_raises_without_fastapi(self) -> None:
+        with patch("champi_stt.api.server.FASTAPI_AVAILABLE", False):
+            from champi_stt.api.server import serve_api
+
+            with pytest.raises(ImportError):
+                serve_api()
+
+    def test_calls_uvicorn(self) -> None:
+        pytest.importorskip("fastapi")
+        with patch("champi_stt.api.server.uvicorn") as mock_uv:
+            from champi_stt.api.server import serve_api
+
+            serve_api(host="0.0.0.0", port=9001)
+            mock_uv.run.assert_called_once()
+            _, kwargs = mock_uv.run.call_args
+            assert kwargs["host"] == "0.0.0.0"
+            assert kwargs["port"] == 9001


### PR DESCRIPTION
## Summary

- Adds `src/champi_stt/api/server.py` with a FastAPI app exposing:
  - `POST /transcribe` — audio file upload, returns JSON `{text, processing_time}`
  - `GET /status` — provider name and readiness
  - `POST /command` — inject text command into an `asyncio.Queue`
  - `WS /stream` — WebSocket streaming via provider's `stream_transcribe()`
- Adds `champi-stt serve` CLI command with `--provider`, `--host`, `--port` options
- Reuses the existing `webui` optional extra (fastapi + uvicorn)
- 12 tests in `tests/test_api_server.py` (10 skipped without fastapi installed)

## Test plan

- [ ] `uv run pytest tests/test_api_server.py -v` — passes (10 skipped without fastapi)
- [ ] `pip install 'champi-stt[webui]' && champi-stt serve --help`