### PR TITLE
feat: benchmark suite for transcription latency and memory (#27)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,59 @@
+name: Benchmarks
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "benchmarks/**"
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Run benchmarks
+        run: |
+          uv run pytest benchmarks/ \
+            --benchmark-only \
+            --benchmark-json=benchmark-results.json \
+            -v
+
+      - name: Run memory tests
+        run: uv run pytest benchmarks/bench_memory.py -v
+
+      - name: Post benchmark summary
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            let body = '## Benchmark Results\n\n';
+            try {
+              const data = JSON.parse(fs.readFileSync('benchmark-results.json', 'utf8'));
+              body += '| Benchmark | Mean (ms) | Std Dev (ms) |\n|---|---|---|\n';
+              for (const bench of data.benchmarks || []) {
+                const mean = (bench.stats.mean * 1000).toFixed(3);
+                const std = (bench.stats.stddev * 1000).toFixed(3);
+                body += `| ${bench.name} | ${mean} | ${std} |\n`;
+              }
+            } catch (e) {
+              body += '_No benchmark data available._\n';
+            }
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });

--- a/benchmarks/bench_memory.py
+++ b/benchmarks/bench_memory.py
@@ -1,0 +1,53 @@
+"""
+Memory usage benchmarks for audio processing.
+
+Uses tracemalloc to measure peak allocation during key operations.
+These are unit-style tests that assert on memory bounds, not timed
+via pytest-benchmark.
+
+Run with:
+    uv run pytest benchmarks/bench_memory.py -v
+"""
+
+from __future__ import annotations
+
+import tracemalloc
+
+import numpy as np
+import pytest
+
+
+def _peak_kb(fn, *args, **kwargs) -> float:
+    tracemalloc.start()
+    fn(*args, **kwargs)
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return peak / 1024
+
+
+class TestMemoryBounds:
+    def test_audio_buffer_1s_under_1mb(self) -> None:
+        """1 second of float32 audio at 16 kHz should stay well under 1 MB."""
+        def _make() -> np.ndarray:
+            return np.zeros(16000, dtype=np.float32)
+
+        peak_kb = _peak_kb(_make)
+        assert peak_kb < 1024, f"Expected < 1024 KB, got {peak_kb:.1f} KB"
+
+    def test_audio_buffer_60s_under_10mb(self) -> None:
+        """60 seconds of float32 audio at 16 kHz: ~3.8 MB array."""
+        def _make() -> np.ndarray:
+            return np.zeros(16000 * 60, dtype=np.float32)
+
+        peak_kb = _peak_kb(_make)
+        assert peak_kb < 10 * 1024, f"Expected < 10 MB, got {peak_kb / 1024:.1f} MB"
+
+    def test_chunk_concat_bounded(self) -> None:
+        """Concatenating 100 chunks of 4096 samples each stays under 4 MB."""
+        chunks = [np.zeros(4096, dtype=np.float32) for _ in range(100)]
+
+        def _concat() -> np.ndarray:
+            return np.concatenate(chunks)
+
+        peak_kb = _peak_kb(_concat)
+        assert peak_kb < 4 * 1024, f"Expected < 4 MB, got {peak_kb / 1024:.1f} MB"

--- a/benchmarks/bench_transcription.py
+++ b/benchmarks/bench_transcription.py
@@ -1,0 +1,73 @@
+"""
+Transcription latency benchmarks.
+
+Measures end-to-end transcribe() latency for each provider using mocked
+network/model calls, so this runs in CI without API keys or GPU.
+
+Run with:
+    uv run pytest benchmarks/ --benchmark-only -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+from typing import Any
+
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_provider(response: str = "hello world") -> Any:
+    prov = MagicMock()
+    prov.is_loaded = True
+    prov.transcribe = AsyncMock(return_value=response)
+    return prov
+
+
+def _run_transcribe(provider: Any, audio: np.ndarray) -> str:
+    return asyncio.get_event_loop().run_until_complete(provider.transcribe(audio))
+
+
+# ---------------------------------------------------------------------------
+# Latency benchmarks
+# ---------------------------------------------------------------------------
+
+def test_bench_mock_provider_1s(benchmark, sample_audio_1s: np.ndarray) -> None:
+    """Baseline: mock provider transcription latency on 1s audio."""
+    prov = _make_mock_provider()
+    result = benchmark(_run_transcribe, prov, sample_audio_1s)
+    assert result == "hello world"
+
+
+def test_bench_mock_provider_5s(benchmark, sample_audio_5s: np.ndarray) -> None:
+    """Baseline: mock provider transcription latency on 5s audio."""
+    prov = _make_mock_provider()
+    result = benchmark(_run_transcribe, prov, sample_audio_5s)
+    assert result == "hello world"
+
+
+def test_bench_generate_audio_1s(benchmark) -> None:
+    """Audio generation latency (baseline for numpy overhead)."""
+    def _gen() -> np.ndarray:
+        t = np.linspace(0, 1.0, 16000, endpoint=False)
+        return np.sin(2 * np.pi * 440 * t).astype(np.float32)
+
+    audio = benchmark(_gen)
+    assert audio.shape == (16000,)
+
+
+def test_bench_streaming_chunk_assembly(benchmark, sample_audio_5s: np.ndarray) -> None:
+    """Latency of assembling streaming chunks (numpy concat)."""
+    chunk_size = 4096
+    chunks = [sample_audio_5s[i:i + chunk_size] for i in range(0, len(sample_audio_5s), chunk_size)]
+
+    def _assemble() -> np.ndarray:
+        return np.concatenate(chunks)
+
+    assembled = benchmark(_assemble)
+    assert len(assembled) == len(sample_audio_5s)

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -1,0 +1,20 @@
+"""Shared fixtures for benchmarks."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture(scope="session")
+def sample_audio_1s() -> np.ndarray:
+    """One second of 440 Hz sine at 16 kHz, float32."""
+    t = np.linspace(0, 1.0, 16000, endpoint=False)
+    return (np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+
+
+@pytest.fixture(scope="session")
+def sample_audio_5s() -> np.ndarray:
+    """Five seconds of 440 Hz sine at 16 kHz, float32."""
+    t = np.linspace(0, 5.0, 80000, endpoint=False)
+    return (np.sin(2 * np.pi * 440 * t)).astype(np.float32)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ dev = [
     "twine",
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
+    "pytest-benchmark>=4.0.0",
     "pytest-cov>=4.0.0",
     "pytest-mock",
     "black>=23.0.0",


### PR DESCRIPTION
## Summary

- Adds `benchmarks/bench_transcription.py` — pytest-benchmark latency tests using mock providers (no GPU/API keys needed): 1s audio, 5s audio, audio generation, chunk assembly
- Adds `benchmarks/bench_memory.py` — tracemalloc peak-allocation assertions: 1s buffer < 1 MB, 60s buffer < 10 MB, 100-chunk concat < 4 MB
- Adds `benchmarks/conftest.py` with shared session-scoped audio fixtures
- Adds `pytest-benchmark>=4.0.0` to `dev` extra in `pyproject.toml`
- Adds `.github/workflows/benchmarks.yml` — runs on PRs touching `src/` or `benchmarks/`, posts results table as a PR comment

## Test plan

- [ ] `uv run pytest benchmarks/bench_memory.py -v` — 3 passed
- [ ] `uv run pytest benchmarks/ --benchmark-only -v` — passes (after `pip install pytest-benchmark`)