### PR TITLE
feat: API reference docs via mkdocstrings (#29)

### DIFF
--- a/docs/api/base_config.md
+++ b/docs/api/base_config.md
@@ -1,0 +1,3 @@
+# BaseSTTConfig
+
+::: champi_stt.core.base_config.BaseSTTConfig

--- a/docs/api/base_provider.md
+++ b/docs/api/base_provider.md
@@ -1,0 +1,3 @@
+# BaseSTTProvider
+
+::: champi_stt.core.base_provider.BaseSTTProvider

--- a/docs/api/base_transcriber.md
+++ b/docs/api/base_transcriber.md
@@ -1,0 +1,3 @@
+# BaseTranscriber
+
+::: champi_stt.core.base_transcriber.BaseTranscriber

--- a/docs/api/diarization.md
+++ b/docs/api/diarization.md
@@ -1,0 +1,7 @@
+# Diarization
+
+::: champi_stt.diarization.config.DiarizationConfig
+
+::: champi_stt.diarization.diarizer.DiarizationSegment
+
+::: champi_stt.diarization.diarizer.Diarizer

--- a/docs/api/factory.md
+++ b/docs/api/factory.md
@@ -1,0 +1,10 @@
+# Factory
+
+The factory module is the primary entry point for creating STT providers.
+
+::: champi_stt.factory
+    options:
+      members:
+        - get_provider
+        - get_default_provider
+        - list_providers

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,14 @@
+# API Reference
+
+This section documents the complete public API of Champi STT.
+
+See [__init__.py](https://github.com/champi-ai/champi-stt/blob/main/src/champi_stt/__init__.py)
+for the stability tier of each symbol (stable, provisional, internal).
+
+## Stability tiers
+
+| Tier | Guarantee |
+|---|---|
+| **Stable** | Semver — no breaking changes within a major version |
+| **Provisional** | May change in a minor release with a deprecation warning |
+| **Internal** | No guarantee — do not import directly |

--- a/docs/api/multi_room.md
+++ b/docs/api/multi_room.md
@@ -1,0 +1,7 @@
+# Multi-Room Audio
+
+::: champi_stt.core.multi_room.RoomConfig
+
+::: champi_stt.core.multi_room.RoomAudioChunk
+
+::: champi_stt.core.multi_room.MultiRoomAudioManager

--- a/docs/api/response.md
+++ b/docs/api/response.md
@@ -1,0 +1,7 @@
+# Response Types
+
+::: champi_stt.core.response.TranscriptionResponse
+
+::: champi_stt.core.response.TranscriptionSegment
+
+::: champi_stt.core.response.TranscriptionChunk

--- a/docs/api/streaming.md
+++ b/docs/api/streaming.md
@@ -1,0 +1,5 @@
+# Streaming
+
+::: champi_stt.core.streaming.StreamingTranscriptionConfig
+
+::: champi_stt.core.response.TranscriptionChunk

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,16 @@ theme:
 
 plugins:
   - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            show_source: true
+            show_root_heading: true
+            heading_level: 2
+            docstring_style: google
+            members_order: source
+            show_signature_annotations: true
 
 nav:
   - Home: index.md
@@ -36,6 +46,17 @@ nav:
       - Installation: getting-started/installation.md
       - Quick Start: getting-started/quickstart.md
   - Architecture: architecture.md
+  - API Reference:
+      - Overview: api/index.md
+      - Factory: api/factory.md
+      - Base Classes:
+          - BaseSTTProvider: api/base_provider.md
+          - BaseSTTConfig: api/base_config.md
+          - BaseTranscriber: api/base_transcriber.md
+      - Streaming: api/streaming.md
+      - Multi-Room Audio: api/multi_room.md
+      - Diarization: api/diarization.md
+      - Response Types: api/response.md
   - Features:
       - IPC System: features/ipc.md
       - ImGui Integration: features/imgui.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ all = [
 docs = [
     "mkdocs>=1.5.0",
     "mkdocs-material>=9.0.0",
+    "mkdocstrings[python]>=0.24.0",
 ]
 
 # Development tools

--- a/src/champi_stt/factory.py
+++ b/src/champi_stt/factory.py
@@ -1,4 +1,8 @@
-"""Provider factory for creating STT providers."""
+"""Provider factory for creating STT providers.
+
+This is the primary entry point for instantiating STT providers.
+Use :func:`get_provider` to create any supported provider by key.
+"""
 
 from typing import Any
 
@@ -64,10 +68,19 @@ def get_provider(
 
 
 def list_providers() -> list[str]:
-    """Return the list of registered provider keys."""
+    """Return the list of registered provider keys.
+
+    Returns:
+        List of provider key strings accepted by :func:`get_provider`.
+    """
     return list(_SUPPORTED_PROVIDERS)
 
 
 def get_default_provider() -> BaseSTTProvider:
-    """Return the default provider (WhisperLive, local inference)."""
+    """Return the default provider (WhisperLive, local inference).
+
+    Returns:
+        An uninitialized :class:`~champi_stt.core.base_provider.BaseSTTProvider`
+        backed by WhisperLive.
+    """
     return get_provider("whisperlive")


### PR DESCRIPTION
## Summary

- Adds `docs/api/` with pages for: factory, BaseSTTProvider, BaseSTTConfig, BaseTranscriber, streaming, multi-room, diarization, and response types
- Each page uses `:::` mkdocstrings autodoc directives rendering class/function docstrings from source
- Updates `mkdocs.yml` with mkdocstrings plugin (Google docstring style, source links, signature annotations) and API Reference navigation section
- Adds `mkdocstrings[python]>=0.24.0` to the `docs` optional extra
- Improves `factory.py` docstrings for `list_providers()` and `get_default_provider()`

## Test plan

- [ ] `pip install "champi-stt[docs]" && mkdocs build --strict` completes without errors
- [ ] GitHub Pages deployment shows the API Reference section