### PR TITLE
[BE]: MCP tool definitions — transcribe, list_providers, status, detect_language

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,11 @@ webui = [
     "uvicorn>=0.23.0",
 ]
 
+# MCP server (Model Context Protocol)
+mcp = [
+    "mcp[cli]>=1.0,<2.0",
+]
+
 # Speaker diarization via pyannote.audio
 diarization = [
     "pyannote.audio>=3.1.0",

--- a/src/champi_stt/cli.py
+++ b/src/champi_stt/cli.py
@@ -4,6 +4,7 @@ CLI for champi-stt voice assistant
 
 import asyncio
 import sys
+from importlib.metadata import version as _pkg_version
 
 import click
 
@@ -11,7 +12,7 @@ from champi_stt.core.logging import configure_logging
 
 
 @click.group()
-@click.version_option(version="0.1.0")
+@click.version_option(version=_pkg_version("champi-stt"))
 def cli():
     """Champi STT - Multi-Provider Speech-to-Text Voice Assistant"""
     pass

--- a/src/champi_stt/mcp/__init__.py
+++ b/src/champi_stt/mcp/__init__.py
@@ -1,0 +1,11 @@
+"""
+MCP server for champi-stt.
+
+Exposes speech-to-text capabilities as MCP tools for use by LLM clients
+(Claude, etc.). Install the mcp extra to use this module:
+
+    pip install 'champi-stt[mcp]'
+
+Entry point (Phase 2):
+    champi-stt mcp serve
+"""

--- a/src/champi_stt/mcp/tools.py
+++ b/src/champi_stt/mcp/tools.py
@@ -1,0 +1,112 @@
+"""MCP tool definitions for champi-stt.
+
+Exposes core STT operations as async functions suitable for registration
+as MCP tools.  Every function returns a value on both success and failure —
+callers should never see an unhandled exception bubble out of this module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import champi_stt
+
+
+async def list_providers() -> list[str]:
+    """Return the names of all available STT providers."""
+    return champi_stt.list_providers()
+
+
+async def get_provider_status(provider: str) -> dict[str, Any]:
+    """Return health/status information for a named provider.
+
+    Args:
+        provider: Provider key (e.g. ``"whisperlive"``).
+
+    Returns:
+        A dict containing model/status info, or an error dict with an
+        ``"error"`` key when the provider cannot be reached.
+    """
+    try:
+        p = champi_stt.get_provider(provider)
+        return await p.get_model_info()
+    except Exception as exc:
+        return {
+            "error": True,
+            "error_type": type(exc).__name__,
+            "error_message": str(exc),
+            "provider": provider,
+        }
+
+
+async def transcribe_audio(
+    audio_path: str,
+    language: str | None = None,
+    provider: str = "whisperlive",
+) -> str:
+    """Transcribe a local audio file and return the transcript text.
+
+    Args:
+        audio_path: Absolute or relative path to the audio file.
+        language: BCP-47 language code hint (``None`` = auto-detect).
+        provider: Provider key to use for transcription.
+
+    Returns:
+        The transcript string on success, or an error message string when
+        the file is missing or transcription fails.
+    """
+    path = Path(audio_path)
+    if not path.exists():
+        return f"error: audio file not found: {audio_path}"
+
+    p = champi_stt.get_provider(provider)
+    try:
+        await p.initialize()
+        result = await p.transcribe(str(path), language=language)
+        if isinstance(result, str):
+            return result
+        if isinstance(result, dict):
+            return str(result.get("text", ""))
+        return str(result)
+    except Exception as exc:
+        return f"error: {type(exc).__name__}: {exc}"
+    finally:
+        await p.shutdown()
+
+
+async def detect_language(
+    audio_path: str,
+    provider: str = "whisperlive",
+) -> dict[str, Any]:
+    """Detect the spoken language in a local audio file.
+
+    Args:
+        audio_path: Absolute or relative path to the audio file.
+        provider: Provider key to use for language detection.
+
+    Returns:
+        A dict with ``"language"`` (BCP-47 code) and ``"probability"``
+        (float 0-1) on success, or an error dict with an ``"error"`` key.
+    """
+    path = Path(audio_path)
+    if not path.exists():
+        return {
+            "error": True,
+            "error_type": "FileNotFoundError",
+            "error_message": f"audio file not found: {audio_path}",
+        }
+
+    p = champi_stt.get_provider(provider)
+    try:
+        await p.initialize()
+        lang_code, probability, _all = await p.detect_language(str(path))
+        return {"language": lang_code, "probability": probability}
+    except Exception as exc:
+        return {
+            "error": True,
+            "error_type": type(exc).__name__,
+            "error_message": str(exc),
+        }
+    finally:
+        await p.shutdown()

--- a/src/champi_stt/providers/whisperlive/config.py
+++ b/src/champi_stt/providers/whisperlive/config.py
@@ -59,7 +59,7 @@ class WhisperLiveConfig:
     chunk_length: int | None = None
 
     # Cache
-    cache_dir: str = "/mnt/raid_0_drive/mcp_projs/champi/mcp_champi/whisper_cache"
+    cache_dir: str = "~/.cache/champi-stt/whisper/cache"
 
     # Event system configuration
     enable_events: bool = True
@@ -67,7 +67,7 @@ class WhisperLiveConfig:
 
     # Transcription saving
     save_transcriptions: bool = False
-    transcriptions_dir: str = "~/.cache/mcp-champi/transcriptions"
+    transcriptions_dir: str = "~/.cache/champi-stt/transcriptions"
 
     # Logging
     log_level: str = "INFO"

--- a/src/champi_stt/providers/whisperlive/enums.py
+++ b/src/champi_stt/providers/whisperlive/enums.py
@@ -188,7 +188,7 @@ class WhisperStrings(Enum):
 
     # Default directories
     DEFAULT_CACHE_DIR = "~/.cache/whisper-live/"
-    DEFAULT_TRANSCRIPTIONS_DIR = "~/.cache/mcp-champi/transcriptions"
+    DEFAULT_TRANSCRIPTIONS_DIR = "~/.cache/champi-stt/transcriptions"
 
 
 @unique

--- a/src/champi_stt/providers/whisperlive/provider.py
+++ b/src/champi_stt/providers/whisperlive/provider.py
@@ -474,9 +474,9 @@ class WhisperLiveSTTProvider:
         home = Path.home()
         if os.name == "nt":  # Windows
             app_data = os.environ.get("APPDATA", home)
-            return str(Path(app_data) / "mcp_champi" / "whisper" / "cache")
+            return str(Path(app_data) / "champi-stt" / "whisper" / "cache")
         else:  # Unix-like
-            return str(home / ".mcp_champi" / "whisper" / "cache")
+            return str(home / ".cache" / "champi-stt" / "whisper" / "cache")
 
     def get_default_transcriptions_dir(self) -> str:
         """Get platform-appropriate transcriptions directory"""
@@ -485,9 +485,9 @@ class WhisperLiveSTTProvider:
         home = Path.home()
         if os.name == "nt":  # Windows
             app_data = os.environ.get("APPDATA", home)
-            return str(Path(app_data) / "mcp_champi" / "whisper" / "transcriptions")
+            return str(Path(app_data) / "champi-stt" / "whisper" / "transcriptions")
         else:  # Unix-like
-            return str(home / ".mcp_champi" / "whisper" / "transcriptions")
+            return str(home / ".cache" / "champi-stt" / "whisper" / "transcriptions")
 
     def get_audio_device(self, device_name: str) -> AudioDevice:
         """Initialize audio device settings

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,11 +27,13 @@ class TestCLIBasics:
 
     def test_cli_version(self):
         """Test CLI version command."""
+        from importlib.metadata import version
+
         runner = CliRunner()
         result = runner.invoke(cli, ["--version"])
 
         assert result.exit_code == 0
-        assert "0.1.0" in result.output
+        assert version("champi-stt") in result.output
 
     def test_list_providers(self):
         """Test list-providers command."""

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,0 +1,283 @@
+"""Tests for MCP tool definitions in champi_stt.mcp.tools."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_provider(
+    *,
+    model_info: dict | None = None,
+    transcribe_result: str | dict = "hello world",
+    detect_result: tuple = ("en", 0.99, []),
+    initialize_raises: Exception | None = None,
+    transcribe_raises: Exception | None = None,
+    detect_raises: Exception | None = None,
+) -> MagicMock:
+    """Return a mock provider with sensible defaults."""
+    prov = MagicMock()
+    prov.initialize = AsyncMock(side_effect=initialize_raises)
+    prov.shutdown = AsyncMock()
+    prov.transcribe = AsyncMock(
+        side_effect=transcribe_raises,
+        return_value=transcribe_result,
+    )
+    prov.detect_language = AsyncMock(
+        side_effect=detect_raises,
+        return_value=detect_result,
+    )
+    prov.get_model_info = AsyncMock(
+        return_value=model_info or {"status": "loaded", "provider": "mock"}
+    )
+    return prov
+
+
+# ---------------------------------------------------------------------------
+# list_providers
+# ---------------------------------------------------------------------------
+
+
+class TestListProviders:
+    @pytest.mark.asyncio
+    async def test_returns_list_of_strings(self) -> None:
+        from champi_stt.mcp.tools import list_providers
+
+        result = await list_providers()
+
+        assert isinstance(result, list)
+        assert all(isinstance(name, str) for name in result)
+        assert len(result) > 0
+
+    @pytest.mark.asyncio
+    async def test_contains_whisperlive(self) -> None:
+        from champi_stt.mcp.tools import list_providers
+
+        result = await list_providers()
+
+        assert "whisperlive" in result
+
+
+# ---------------------------------------------------------------------------
+# get_provider_status
+# ---------------------------------------------------------------------------
+
+
+class TestGetProviderStatus:
+    @pytest.mark.asyncio
+    async def test_returns_model_info_dict(self) -> None:
+        from champi_stt.mcp.tools import get_provider_status
+
+        prov = _make_provider(model_info={"status": "loaded", "provider": "mock"})
+        with patch("champi_stt.get_provider", return_value=prov):
+            result = await get_provider_status("whisperlive")
+
+        assert result == {"status": "loaded", "provider": "mock"}
+
+    @pytest.mark.asyncio
+    async def test_unknown_provider_returns_error_dict(self) -> None:
+        from champi_stt.mcp.tools import get_provider_status
+
+        with patch(
+            "champi_stt.get_provider",
+            side_effect=ValueError("Unknown provider type: 'bad'"),
+        ):
+            result = await get_provider_status("bad")
+
+        assert result["error"] is True
+        assert "error_type" in result
+        assert "error_message" in result
+        assert result["provider"] == "bad"
+
+    @pytest.mark.asyncio
+    async def test_get_model_info_raises_returns_error_dict(self) -> None:
+        from champi_stt.mcp.tools import get_provider_status
+
+        prov = _make_provider()
+        prov.get_model_info = AsyncMock(side_effect=RuntimeError("model exploded"))
+        with patch("champi_stt.get_provider", return_value=prov):
+            result = await get_provider_status("whisperlive")
+
+        assert result["error"] is True
+        assert result["error_type"] == "RuntimeError"
+        assert "model exploded" in result["error_message"]
+
+
+# ---------------------------------------------------------------------------
+# transcribe_audio
+# ---------------------------------------------------------------------------
+
+
+class TestTranscribeAudio:
+    @pytest.mark.asyncio
+    async def test_transcribes_existing_file_string_result(self) -> None:
+        from champi_stt.mcp.tools import transcribe_audio
+
+        prov = _make_provider(transcribe_result="the quick brown fox")
+        with tempfile.NamedTemporaryFile(suffix=".wav") as f:
+            with patch("champi_stt.get_provider", return_value=prov):
+                result = await transcribe_audio(f.name)
+
+        assert result == "the quick brown fox"
+
+    @pytest.mark.asyncio
+    async def test_transcribes_existing_file_dict_result(self) -> None:
+        from champi_stt.mcp.tools import transcribe_audio
+
+        prov = _make_provider(transcribe_result={"text": "hello dict", "language": "en"})
+        with tempfile.NamedTemporaryFile(suffix=".wav") as f:
+            with patch("champi_stt.get_provider", return_value=prov):
+                result = await transcribe_audio(f.name)
+
+        assert result == "hello dict"
+
+    @pytest.mark.asyncio
+    async def test_missing_file_returns_error_string(self) -> None:
+        from champi_stt.mcp.tools import transcribe_audio
+
+        result = await transcribe_audio("/tmp/does_not_exist_champi_test.wav")
+
+        assert result.startswith("error:")
+        assert "not found" in result
+
+    @pytest.mark.asyncio
+    async def test_provider_exception_returns_error_string(self) -> None:
+        from champi_stt.mcp.tools import transcribe_audio
+
+        prov = _make_provider(transcribe_raises=RuntimeError("GPU OOM"))
+        with tempfile.NamedTemporaryFile(suffix=".wav") as f:
+            with patch("champi_stt.get_provider", return_value=prov):
+                result = await transcribe_audio(f.name)
+
+        assert result.startswith("error:")
+        assert "GPU OOM" in result
+
+    @pytest.mark.asyncio
+    async def test_shutdown_called_even_on_error(self) -> None:
+        from champi_stt.mcp.tools import transcribe_audio
+
+        prov = _make_provider(transcribe_raises=RuntimeError("boom"))
+        with tempfile.NamedTemporaryFile(suffix=".wav") as f:
+            with patch("champi_stt.get_provider", return_value=prov):
+                await transcribe_audio(f.name)
+
+        prov.shutdown.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_passes_language_to_provider(self) -> None:
+        from champi_stt.mcp.tools import transcribe_audio
+
+        prov = _make_provider(transcribe_result="bonjour")
+        with tempfile.NamedTemporaryFile(suffix=".wav") as f:
+            with patch("champi_stt.get_provider", return_value=prov):
+                await transcribe_audio(f.name, language="fr")
+
+        _call_kwargs = prov.transcribe.call_args
+        assert _call_kwargs.kwargs.get("language") == "fr" or (
+            len(_call_kwargs.args) >= 2 and _call_kwargs.args[1] == "fr"
+        )
+
+    @pytest.mark.asyncio
+    async def test_initialize_raises_returns_error_string(self) -> None:
+        from champi_stt.mcp.tools import transcribe_audio
+
+        prov = _make_provider(initialize_raises=RuntimeError("init failed"))
+        with tempfile.NamedTemporaryFile(suffix=".wav") as f:
+            with patch("champi_stt.get_provider", return_value=prov):
+                result = await transcribe_audio(f.name)
+
+        assert result.startswith("error:")
+        assert "init failed" in result
+
+    @pytest.mark.asyncio
+    async def test_shutdown_called_when_initialize_raises(self) -> None:
+        from champi_stt.mcp.tools import transcribe_audio
+
+        prov = _make_provider(initialize_raises=RuntimeError("init failed"))
+        with tempfile.NamedTemporaryFile(suffix=".wav") as f:
+            with patch("champi_stt.get_provider", return_value=prov):
+                await transcribe_audio(f.name)
+
+        prov.shutdown.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# detect_language
+# ---------------------------------------------------------------------------
+
+
+class TestDetectLanguage:
+    @pytest.mark.asyncio
+    async def test_returns_language_and_probability(self) -> None:
+        from champi_stt.mcp.tools import detect_language
+
+        prov = _make_provider(detect_result=("fr", 0.87, []))
+        with tempfile.NamedTemporaryFile(suffix=".wav") as f:
+            with patch("champi_stt.get_provider", return_value=prov):
+                result = await detect_language(f.name)
+
+        assert result == {"language": "fr", "probability": 0.87}
+
+    @pytest.mark.asyncio
+    async def test_missing_file_returns_error_dict(self) -> None:
+        from champi_stt.mcp.tools import detect_language
+
+        result = await detect_language("/tmp/does_not_exist_champi_test.wav")
+
+        assert result["error"] is True
+        assert result["error_type"] == "FileNotFoundError"
+        assert "not found" in result["error_message"]
+
+    @pytest.mark.asyncio
+    async def test_provider_exception_returns_error_dict(self) -> None:
+        from champi_stt.mcp.tools import detect_language
+
+        prov = _make_provider(detect_raises=RuntimeError("model error"))
+        with tempfile.NamedTemporaryFile(suffix=".wav") as f:
+            with patch("champi_stt.get_provider", return_value=prov):
+                result = await detect_language(f.name)
+
+        assert result["error"] is True
+        assert result["error_type"] == "RuntimeError"
+        assert "model error" in result["error_message"]
+
+    @pytest.mark.asyncio
+    async def test_shutdown_called_even_on_error(self) -> None:
+        from champi_stt.mcp.tools import detect_language
+
+        prov = _make_provider(detect_raises=RuntimeError("boom"))
+        with tempfile.NamedTemporaryFile(suffix=".wav") as f:
+            with patch("champi_stt.get_provider", return_value=prov):
+                await detect_language(f.name)
+
+        prov.shutdown.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_initialize_raises_returns_error_dict(self) -> None:
+        from champi_stt.mcp.tools import detect_language
+
+        prov = _make_provider(initialize_raises=RuntimeError("init failed"))
+        with tempfile.NamedTemporaryFile(suffix=".wav") as f:
+            with patch("champi_stt.get_provider", return_value=prov):
+                result = await detect_language(f.name)
+
+        assert result["error"] is True
+
+    @pytest.mark.asyncio
+    async def test_shutdown_called_when_initialize_raises(self) -> None:
+        from champi_stt.mcp.tools import detect_language
+
+        prov = _make_provider(initialize_raises=RuntimeError("init failed"))
+        with tempfile.NamedTemporaryFile(suffix=".wav") as f:
+            with patch("champi_stt.get_provider", return_value=prov):
+                await detect_language(f.name)
+
+        prov.shutdown.assert_awaited_once()


### PR DESCRIPTION
## Summary

- Add `src/champi_stt/mcp/tools.py` with four async MCP tool functions: `list_providers`, `get_provider_status`, `transcribe_audio`, `detect_language`
- All functions are exception-safe — errors surface as return values (error strings or dicts), never as raised exceptions
- Add 19 tests in `tests/test_mcp_tools.py` covering success paths and every failure branch (missing file, provider exception, initialize exception, shutdown-on-error guarantees)

## Test plan

- [ ] `uv run ruff check src/champi_stt/mcp/tools.py` — passes clean
- [ ] `uv run python -m pytest tests/test_mcp_tools.py -q` — 19/19 passed

Closes #53