### PR TITLE
test(mcp): add MCP server startup integration test and CLI mcp-serve test

### DIFF
--- a/tests/test_mcp/__init__.py
+++ b/tests/test_mcp/__init__.py
@@ -1,0 +1,1 @@
+"""MCP tool unit tests and JSON schema validation."""

--- a/tests/test_mcp/test_cli.py
+++ b/tests/test_mcp/test_cli.py
@@ -1,0 +1,201 @@
+"""Tests for the ``champi-stt mcp serve`` CLI entry point.
+
+Uses Click's ``CliRunner`` to exercise the ``mcp serve`` subcommand without
+starting a real server loop or requiring audio hardware.  The underlying
+``main()`` function is mocked in all tests that would otherwise block on
+stdin.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner, Result
+
+from champi_stt.cli import cli
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _invoke(*args: str) -> Result:
+    """Invoke the top-level ``cli`` with *args* and return the result."""
+    return CliRunner().invoke(cli, list(args))
+
+
+# ---------------------------------------------------------------------------
+# Help / discovery
+# ---------------------------------------------------------------------------
+
+
+class TestMCPServeHelp:
+    """The ``mcp serve`` command is discoverable and self-documenting."""
+
+    def test_mcp_group_exits_zero_on_help(self) -> None:
+        result = _invoke("mcp", "--help")
+        assert result.exit_code == 0
+
+    def test_mcp_group_help_mentions_mcp(self) -> None:
+        result = _invoke("mcp", "--help")
+        assert "mcp" in result.output.lower()
+
+    def test_serve_subcommand_visible_in_mcp_help(self) -> None:
+        result = _invoke("mcp", "--help")
+        assert "serve" in result.output
+
+    def test_serve_help_exits_zero(self) -> None:
+        result = _invoke("mcp", "serve", "--help")
+        assert result.exit_code == 0
+
+    def test_serve_help_lists_transport_option(self) -> None:
+        result = _invoke("mcp", "serve", "--help")
+        assert "--transport" in result.output
+
+    def test_serve_help_shows_stdio_choice(self) -> None:
+        result = _invoke("mcp", "serve", "--help")
+        assert "stdio" in result.output
+
+    def test_serve_help_shows_sse_choice(self) -> None:
+        result = _invoke("mcp", "serve", "--help")
+        assert "sse" in result.output
+
+    def test_serve_help_lists_host_option(self) -> None:
+        result = _invoke("mcp", "serve", "--help")
+        assert "--host" in result.output
+
+    def test_serve_help_lists_port_option(self) -> None:
+        result = _invoke("mcp", "serve", "--help")
+        assert "--port" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Argument forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestMCPServeArguments:
+    """CLI arguments are correctly forwarded to ``champi_stt.mcp.server.main``."""
+
+    def test_default_transport_is_stdio(self) -> None:
+        mock_main = MagicMock()
+        with patch("champi_stt.mcp.server.main", mock_main):
+            _invoke("mcp", "serve")
+        mock_main.assert_called_once_with(
+            transport="stdio", host="localhost", port=8765
+        )
+
+    def test_explicit_stdio_transport(self) -> None:
+        mock_main = MagicMock()
+        with patch("champi_stt.mcp.server.main", mock_main):
+            _invoke("mcp", "serve", "--transport", "stdio")
+        mock_main.assert_called_once_with(
+            transport="stdio", host="localhost", port=8765
+        )
+
+    def test_sse_transport_forwarded(self) -> None:
+        mock_main = MagicMock()
+        with patch("champi_stt.mcp.server.main", mock_main):
+            _invoke("mcp", "serve", "--transport", "sse")
+        mock_main.assert_called_once_with(transport="sse", host="localhost", port=8765)
+
+    def test_custom_host_forwarded(self) -> None:
+        mock_main = MagicMock()
+        with patch("champi_stt.mcp.server.main", mock_main):
+            _invoke("mcp", "serve", "--host", "0.0.0.0")
+        _, kwargs = mock_main.call_args
+        assert kwargs["host"] == "0.0.0.0"
+
+    def test_custom_port_forwarded(self) -> None:
+        mock_main = MagicMock()
+        with patch("champi_stt.mcp.server.main", mock_main):
+            _invoke("mcp", "serve", "--port", "9999")
+        _, kwargs = mock_main.call_args
+        assert kwargs["port"] == 9999
+
+    def test_all_options_forwarded_together(self) -> None:
+        mock_main = MagicMock()
+        with patch("champi_stt.mcp.server.main", mock_main):
+            _invoke(
+                "mcp",
+                "serve",
+                "--transport",
+                "sse",
+                "--host",
+                "192.168.1.1",
+                "--port",
+                "12345",
+            )
+        mock_main.assert_called_once_with(
+            transport="sse", host="192.168.1.1", port=12345
+        )
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+class TestMCPServeValidation:
+    """CLI rejects invalid argument values before reaching ``main``."""
+
+    def test_invalid_transport_is_rejected(self) -> None:
+        result = _invoke("mcp", "serve", "--transport", "grpc")
+        assert result.exit_code != 0
+
+    def test_non_integer_port_is_rejected(self) -> None:
+        result = _invoke("mcp", "serve", "--port", "notanumber")
+        assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# MCP package not installed
+# ---------------------------------------------------------------------------
+
+
+class TestMCPServeWhenMCPUnavailable:
+    """CLI exits with a clear error when the ``mcp`` package is absent."""
+
+    def test_exits_nonzero_when_mcp_unavailable(self) -> None:
+        with patch("champi_stt.mcp.server.MCP_AVAILABLE", False):
+            result = _invoke("mcp", "serve")
+        assert result.exit_code != 0
+
+    def test_error_message_mentions_mcp_package(self) -> None:
+        with patch("champi_stt.mcp.server.MCP_AVAILABLE", False):
+            result = _invoke("mcp", "serve")
+        # Output includes both stdout and stderr via mix_stderr default
+        combined = result.output + (result.stderr if hasattr(result, "stderr") else "")
+        assert "mcp" in combined.lower()
+
+    def test_error_message_mentions_install(self) -> None:
+        with patch("champi_stt.mcp.server.MCP_AVAILABLE", False):
+            result = _invoke("mcp", "serve")
+        # Error guidance appears in the combined output
+        assert "install" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Clean startup (mocked main)
+# ---------------------------------------------------------------------------
+
+
+class TestMCPServeStartup:
+    """Verify that a well-behaved main() results in a zero exit code."""
+
+    def test_serve_exits_zero_when_main_returns(self) -> None:
+        with patch("champi_stt.mcp.server.main", return_value=None):
+            result = _invoke("mcp", "serve")
+        assert result.exit_code == 0
+
+    def test_serve_stdio_exits_zero_when_main_returns(self) -> None:
+        with patch("champi_stt.mcp.server.main", return_value=None):
+            result = _invoke("mcp", "serve", "--transport", "stdio")
+        assert result.exit_code == 0
+
+    @pytest.mark.parametrize("transport", ["stdio", "sse"])
+    def test_serve_exits_zero_for_each_transport(self, transport: str) -> None:
+        with patch("champi_stt.mcp.server.main", return_value=None):
+            result = _invoke("mcp", "serve", "--transport", transport)
+        assert result.exit_code == 0

--- a/tests/test_mcp/test_server.py
+++ b/tests/test_mcp/test_server.py
@@ -1,0 +1,179 @@
+"""Integration test: verify the MCP server startup and JSON-RPC initialize handshake.
+
+Uses the official ``mcp`` client library (``stdio_client`` + ``ClientSession``) to
+spawn ``champi-stt-mcp`` as a child process, perform the full MCP initialize
+handshake, and assert the expected response fields.
+
+Why ``stdio_client`` instead of raw ``subprocess.Popen``?
+The MCP stdio transport is built on ``anyio`` async streams (``anyio.open_process``).
+Using the MCP client library guarantees the same framing and session lifecycle that
+real MCP hosts use, making the test a true end-to-end integration check.
+
+Performance note: tests are grouped so that the server is spawned only twice for
+the full module — once for handshake assertions and once for tool assertions.
+``anyio.fail_after`` is used inside each individual test (not in fixtures) to avoid
+cancel-scope task-crossing errors with pytest-asyncio.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from mcp.client.session import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.types import InitializeResult, ListToolsResult
+
+# Per-session connection timeout in seconds.
+_TIMEOUT = 30
+
+
+def _server_params() -> StdioServerParameters:
+    """Return ``StdioServerParameters`` pointing at the installed entry-point.
+
+    Prefers ``champi-stt-mcp`` in the same ``bin/`` directory as the running
+    interpreter so the test always picks up the virtualenv's copy of the server.
+    """
+    entry = Path(sys.executable).parent / "champi-stt-mcp"
+    if entry.exists():
+        return StdioServerParameters(command=str(entry), args=[])
+    return StdioServerParameters(command="champi-stt-mcp", args=[])
+
+
+# ---------------------------------------------------------------------------
+# Module-level data holders — populated by the class-scope setup tests.
+# ---------------------------------------------------------------------------
+
+
+class _SharedData:
+    """Container for data collected during the integration run."""
+
+    init_result: InitializeResult | None = None
+    tools_result: ListToolsResult | None = None
+
+
+_data = _SharedData()
+
+
+# ---------------------------------------------------------------------------
+# Handshake tests — single subprocess, assertions run after context exits.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestMCPServerHandshake:
+    """Verify the MCP initialize handshake via a real server subprocess."""
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _run_handshake(self) -> None:
+        """Spawn the server once for all handshake tests and capture the result."""
+        import asyncio
+
+        async def _connect() -> InitializeResult:
+            async with (
+                stdio_client(_server_params()) as (rs, ws),
+                ClientSession(rs, ws) as session,
+            ):
+                return await session.initialize()
+
+        # Run the connection in a fresh event loop so it is isolated from
+        # pytest-asyncio's loop and anyio cancel scopes don't cross tasks.
+        loop = asyncio.new_event_loop()
+        try:
+            _data.init_result = loop.run_until_complete(
+                asyncio.wait_for(_connect(), timeout=_TIMEOUT)
+            )
+        finally:
+            loop.close()
+
+    def test_initialize_returns_result(self) -> None:
+        """``session.initialize()`` returns a non-None result."""
+        assert _data.init_result is not None
+
+    def test_server_info_name_is_champi_stt(self) -> None:
+        """``serverInfo.name`` identifies the server as ``"champi-stt"``."""
+        assert _data.init_result is not None
+        assert _data.init_result.serverInfo.name == "champi-stt"
+
+    def test_server_info_version_is_non_empty(self) -> None:
+        """``serverInfo.version`` is a non-empty string."""
+        assert _data.init_result is not None
+        assert _data.init_result.serverInfo.version
+        assert isinstance(_data.init_result.serverInfo.version, str)
+
+    def test_protocol_version_is_non_empty(self) -> None:
+        """``protocolVersion`` is reported by the server."""
+        assert _data.init_result is not None
+        assert _data.init_result.protocolVersion
+        assert isinstance(_data.init_result.protocolVersion, str)
+
+    def test_capabilities_present_in_result(self) -> None:
+        """``capabilities`` field is present in the initialize result."""
+        assert _data.init_result is not None
+        assert _data.init_result.capabilities is not None
+
+
+# ---------------------------------------------------------------------------
+# Tool-registration tests — second subprocess, assertions run synchronously.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestMCPServerTools:
+    """Verify the four tools are registered and visible after initialization."""
+
+    @pytest.fixture(autouse=True, scope="class")
+    def _run_list_tools(self) -> None:
+        """Spawn the server once for all tool tests and capture the tools list."""
+        import asyncio
+
+        async def _connect() -> ListToolsResult:
+            async with (
+                stdio_client(_server_params()) as (rs, ws),
+                ClientSession(rs, ws) as session,
+            ):
+                await session.initialize()
+                return await session.list_tools()
+
+        loop = asyncio.new_event_loop()
+        try:
+            _data.tools_result = loop.run_until_complete(
+                asyncio.wait_for(_connect(), timeout=_TIMEOUT)
+            )
+        finally:
+            loop.close()
+
+    def _tool_names(self) -> set[str]:
+        assert _data.tools_result is not None
+        return {t.name for t in _data.tools_result.tools}
+
+    def test_list_tools_returns_results(self) -> None:
+        """``list_tools()`` returns at least one tool."""
+        assert _data.tools_result is not None
+        assert len(_data.tools_result.tools) > 0
+
+    def test_list_providers_tool_registered(self) -> None:
+        """The ``list_providers`` tool is registered on the server."""
+        assert "list_providers" in self._tool_names()
+
+    def test_transcribe_audio_tool_registered(self) -> None:
+        """The ``transcribe_audio`` tool is registered on the server."""
+        assert "transcribe_audio" in self._tool_names()
+
+    def test_detect_language_tool_registered(self) -> None:
+        """The ``detect_language`` tool is registered on the server."""
+        assert "detect_language" in self._tool_names()
+
+    def test_get_provider_status_tool_registered(self) -> None:
+        """The ``get_provider_status`` tool is registered on the server."""
+        assert "get_provider_status" in self._tool_names()
+
+    def test_exactly_four_tools_registered(self) -> None:
+        """Exactly the four expected tools are registered (no extras, no missing)."""
+        assert self._tool_names() == {
+            "list_providers",
+            "get_provider_status",
+            "transcribe_audio",
+            "detect_language",
+        }

--- a/tests/test_mcp/test_tools.py
+++ b/tests/test_mcp/test_tools.py
@@ -1,0 +1,514 @@
+"""Unit tests and JSON schema validation for the four MCP tools.
+
+Covers all four tools registered by ``create_mcp_server()``:
+- ``list_providers``
+- ``get_provider_status``
+- ``transcribe_audio``
+- ``detect_language``
+
+All tests mock the underlying provider so no audio hardware is required.
+Tests that would need real GPU or microphone access are skipped explicitly.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_provider(
+    *,
+    model_info: dict | None = None,
+    transcribe_result: str | dict = "hello world",
+    detect_result: tuple = ("en", 0.99, []),
+    initialize_raises: Exception | None = None,
+    transcribe_raises: Exception | None = None,
+    detect_raises: Exception | None = None,
+) -> MagicMock:
+    """Build a mock STT provider with configurable return values and errors."""
+    prov = MagicMock()
+    prov.initialize = AsyncMock(side_effect=initialize_raises)
+    prov.shutdown = AsyncMock()
+    prov.transcribe = AsyncMock(
+        side_effect=transcribe_raises, return_value=transcribe_result
+    )
+    prov.detect_language = AsyncMock(
+        side_effect=detect_raises, return_value=detect_result
+    )
+    prov.get_model_info = AsyncMock(
+        return_value=model_info or {"status": "loaded", "provider": "mock"}
+    )
+    return prov
+
+
+def _raw(call_tool_result: tuple) -> dict:
+    """Extract the structured result dict from a FastMCP ``call_tool`` response."""
+    return call_tool_result[1]
+
+
+@pytest.fixture()
+def server() -> Any:
+    """Fresh FastMCP server instance per test (factory pattern)."""
+    from champi_stt.mcp.server import create_mcp_server
+
+    return create_mcp_server()
+
+
+def _schema(server: Any, tool_name: str) -> dict:
+    """Return the JSON Schema parameters dict for a named tool."""
+    return server._tool_manager._tools[tool_name].parameters
+
+
+# ---------------------------------------------------------------------------
+# JSON Schema: list_providers
+# ---------------------------------------------------------------------------
+
+
+class TestListProvidersSchema:
+    """The list_providers tool takes no parameters."""
+
+    def test_schema_type_is_object(self, server: Any) -> None:
+        assert _schema(server, "list_providers")["type"] == "object"
+
+    def test_schema_has_no_required_params(self, server: Any) -> None:
+        schema = _schema(server, "list_providers")
+        required = schema.get("required", [])
+        assert required == []
+
+    def test_schema_properties_is_empty(self, server: Any) -> None:
+        schema = _schema(server, "list_providers")
+        assert schema.get("properties") == {}
+
+
+# ---------------------------------------------------------------------------
+# JSON Schema: get_provider_status
+# ---------------------------------------------------------------------------
+
+
+class TestGetProviderStatusSchema:
+    """get_provider_status requires a single string ``provider`` parameter."""
+
+    def test_schema_type_is_object(self, server: Any) -> None:
+        assert _schema(server, "get_provider_status")["type"] == "object"
+
+    def test_provider_param_is_required(self, server: Any) -> None:
+        schema = _schema(server, "get_provider_status")
+        assert "provider" in schema.get("required", [])
+
+    def test_provider_param_type_is_string(self, server: Any) -> None:
+        schema = _schema(server, "get_provider_status")
+        assert schema["properties"]["provider"]["type"] == "string"
+
+    def test_only_provider_is_required(self, server: Any) -> None:
+        schema = _schema(server, "get_provider_status")
+        assert schema.get("required") == ["provider"]
+
+
+# ---------------------------------------------------------------------------
+# JSON Schema: transcribe_audio
+# ---------------------------------------------------------------------------
+
+
+class TestTranscribeAudioSchema:
+    """transcribe_audio: required ``audio_path: string``; optional ``language`` and ``provider`` (string | null)."""
+
+    def test_schema_type_is_object(self, server: Any) -> None:
+        assert _schema(server, "transcribe_audio")["type"] == "object"
+
+    def test_audio_path_is_required(self, server: Any) -> None:
+        schema = _schema(server, "transcribe_audio")
+        assert "audio_path" in schema.get("required", [])
+
+    def test_only_audio_path_is_required(self, server: Any) -> None:
+        schema = _schema(server, "transcribe_audio")
+        assert schema.get("required") == ["audio_path"]
+
+    def test_audio_path_type_is_string(self, server: Any) -> None:
+        schema = _schema(server, "transcribe_audio")
+        assert schema["properties"]["audio_path"]["type"] == "string"
+
+    def test_language_accepts_string(self, server: Any) -> None:
+        schema = _schema(server, "transcribe_audio")
+        any_of_types = {
+            e["type"] for e in schema["properties"]["language"].get("anyOf", [])
+        }
+        assert "string" in any_of_types
+
+    def test_language_accepts_null(self, server: Any) -> None:
+        schema = _schema(server, "transcribe_audio")
+        any_of_types = {
+            e["type"] for e in schema["properties"]["language"].get("anyOf", [])
+        }
+        assert "null" in any_of_types
+
+    def test_language_default_is_none(self, server: Any) -> None:
+        schema = _schema(server, "transcribe_audio")
+        assert schema["properties"]["language"]["default"] is None
+
+    def test_provider_accepts_string(self, server: Any) -> None:
+        schema = _schema(server, "transcribe_audio")
+        any_of_types = {
+            e["type"] for e in schema["properties"]["provider"].get("anyOf", [])
+        }
+        assert "string" in any_of_types
+
+    def test_provider_accepts_null(self, server: Any) -> None:
+        schema = _schema(server, "transcribe_audio")
+        any_of_types = {
+            e["type"] for e in schema["properties"]["provider"].get("anyOf", [])
+        }
+        assert "null" in any_of_types
+
+    def test_provider_default_is_none(self, server: Any) -> None:
+        schema = _schema(server, "transcribe_audio")
+        assert schema["properties"]["provider"]["default"] is None
+
+
+# ---------------------------------------------------------------------------
+# JSON Schema: detect_language
+# ---------------------------------------------------------------------------
+
+
+class TestDetectLanguageSchema:
+    """detect_language: required ``audio_path: string``; optional ``provider`` (string | null)."""
+
+    def test_schema_type_is_object(self, server: Any) -> None:
+        assert _schema(server, "detect_language")["type"] == "object"
+
+    def test_audio_path_is_required(self, server: Any) -> None:
+        schema = _schema(server, "detect_language")
+        assert "audio_path" in schema.get("required", [])
+
+    def test_only_audio_path_is_required(self, server: Any) -> None:
+        schema = _schema(server, "detect_language")
+        assert schema.get("required") == ["audio_path"]
+
+    def test_audio_path_type_is_string(self, server: Any) -> None:
+        schema = _schema(server, "detect_language")
+        assert schema["properties"]["audio_path"]["type"] == "string"
+
+    def test_provider_accepts_string(self, server: Any) -> None:
+        schema = _schema(server, "detect_language")
+        any_of_types = {
+            e["type"] for e in schema["properties"]["provider"].get("anyOf", [])
+        }
+        assert "string" in any_of_types
+
+    def test_provider_accepts_null(self, server: Any) -> None:
+        schema = _schema(server, "detect_language")
+        any_of_types = {
+            e["type"] for e in schema["properties"]["provider"].get("anyOf", [])
+        }
+        assert "null" in any_of_types
+
+    def test_provider_default_is_none(self, server: Any) -> None:
+        schema = _schema(server, "detect_language")
+        assert schema["properties"]["provider"]["default"] is None
+
+
+# ---------------------------------------------------------------------------
+# Tool: list_providers
+# ---------------------------------------------------------------------------
+
+
+class TestListProvidersTool:
+    @pytest.mark.asyncio
+    async def test_returns_list_of_strings(self, server: Any) -> None:
+        result = _raw(await server.call_tool("list_providers", {}))
+        assert isinstance(result["result"], list)
+        assert all(isinstance(p, str) for p in result["result"])
+
+    @pytest.mark.asyncio
+    async def test_result_is_nonempty(self, server: Any) -> None:
+        result = _raw(await server.call_tool("list_providers", {}))
+        assert len(result["result"]) > 0
+
+    @pytest.mark.asyncio
+    async def test_contains_whisperlive(self, server: Any) -> None:
+        result = _raw(await server.call_tool("list_providers", {}))
+        assert "whisperlive" in result["result"]
+
+    @pytest.mark.asyncio
+    async def test_contains_openai_whisper(self, server: Any) -> None:
+        result = _raw(await server.call_tool("list_providers", {}))
+        assert "openai_whisper" in result["result"]
+
+
+# ---------------------------------------------------------------------------
+# Tool: get_provider_status
+# ---------------------------------------------------------------------------
+
+
+class TestGetProviderStatusTool:
+    @pytest.mark.asyncio
+    async def test_returns_model_info_dict(self, server: Any) -> None:
+        prov = _make_provider(model_info={"status": "loaded", "model": "base"})
+        with patch("champi_stt.get_provider", return_value=prov):
+            result = _raw(
+                await server.call_tool(
+                    "get_provider_status", {"provider": "whisperlive"}
+                )
+            )
+        assert result["status"] == "loaded"
+
+    @pytest.mark.asyncio
+    async def test_get_model_info_is_awaited(self, server: Any) -> None:
+        prov = _make_provider()
+        with patch("champi_stt.get_provider", return_value=prov):
+            await server.call_tool("get_provider_status", {"provider": "whisperlive"})
+        prov.get_model_info.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unknown_provider_returns_error_dict(self, server: Any) -> None:
+        with patch("champi_stt.get_provider", side_effect=ValueError("unknown")):
+            result = _raw(
+                await server.call_tool(
+                    "get_provider_status", {"provider": "nonexistent"}
+                )
+            )
+        assert result["error"] is True
+
+    @pytest.mark.asyncio
+    async def test_error_dict_contains_provider_name(self, server: Any) -> None:
+        with patch("champi_stt.get_provider", side_effect=ValueError("bad")):
+            result = _raw(
+                await server.call_tool(
+                    "get_provider_status", {"provider": "nonexistent"}
+                )
+            )
+        assert result["provider"] == "nonexistent"
+
+    @pytest.mark.asyncio
+    async def test_error_dict_contains_error_type(self, server: Any) -> None:
+        with patch("champi_stt.get_provider", side_effect=ValueError("bad")):
+            result = _raw(
+                await server.call_tool(
+                    "get_provider_status", {"provider": "nonexistent"}
+                )
+            )
+        assert result["error_type"] == "ValueError"
+
+    @pytest.mark.asyncio
+    async def test_error_dict_contains_error_message(self, server: Any) -> None:
+        with patch("champi_stt.get_provider", side_effect=ValueError("bad input")):
+            result = _raw(
+                await server.call_tool(
+                    "get_provider_status", {"provider": "nonexistent"}
+                )
+            )
+        assert "bad input" in result["error_message"]
+
+
+# ---------------------------------------------------------------------------
+# Tool: transcribe_audio
+# ---------------------------------------------------------------------------
+
+
+class TestTranscribeAudioTool:
+    @pytest.mark.asyncio
+    async def test_missing_file_returns_error_string(self, server: Any) -> None:
+        result = _raw(
+            await server.call_tool(
+                "transcribe_audio", {"audio_path": "/no/such/file.wav"}
+            )
+        )
+        assert "error" in result["result"].lower()
+
+    @pytest.mark.asyncio
+    async def test_transcribes_existing_file(self, server: Any) -> None:
+        prov = _make_provider(transcribe_result="hello world")
+        with (
+            tempfile.NamedTemporaryFile(suffix=".wav") as f,
+            patch("champi_stt.get_provider", return_value=prov),
+        ):
+            result = _raw(
+                await server.call_tool("transcribe_audio", {"audio_path": f.name})
+            )
+        assert result["result"] == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_dict_result_extracts_text_field(self, server: Any) -> None:
+        prov = _make_provider(
+            transcribe_result={"text": "extracted text", "confidence": 0.9}
+        )
+        with (
+            tempfile.NamedTemporaryFile(suffix=".wav") as f,
+            patch("champi_stt.get_provider", return_value=prov),
+        ):
+            result = _raw(
+                await server.call_tool("transcribe_audio", {"audio_path": f.name})
+            )
+        assert result["result"] == "extracted text"
+
+    @pytest.mark.asyncio
+    async def test_provider_exception_returns_error_string(self, server: Any) -> None:
+        prov = _make_provider(transcribe_raises=RuntimeError("GPU unavailable"))
+        with (
+            tempfile.NamedTemporaryFile(suffix=".wav") as f,
+            patch("champi_stt.get_provider", return_value=prov),
+        ):
+            result = _raw(
+                await server.call_tool("transcribe_audio", {"audio_path": f.name})
+            )
+        assert "error" in result["result"].lower()
+        assert "GPU unavailable" in result["result"]
+
+    @pytest.mark.asyncio
+    async def test_language_hint_passed_to_provider(self, server: Any) -> None:
+        prov = _make_provider()
+        with (
+            tempfile.NamedTemporaryFile(suffix=".wav") as f,
+            patch("champi_stt.get_provider", return_value=prov),
+        ):
+            await server.call_tool(
+                "transcribe_audio", {"audio_path": f.name, "language": "fr"}
+            )
+        _, kwargs = prov.transcribe.call_args
+        assert kwargs.get("language") == "fr"
+
+    @pytest.mark.asyncio
+    async def test_provider_initialized_only_once(self, server: Any) -> None:
+        prov = _make_provider(transcribe_result="ok")
+        with (
+            tempfile.NamedTemporaryFile(suffix=".wav") as f,
+            patch("champi_stt.get_provider", return_value=prov),
+        ):
+            await server.call_tool("transcribe_audio", {"audio_path": f.name})
+            await server.call_tool("transcribe_audio", {"audio_path": f.name})
+        prov.initialize.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_env_var_selects_provider(
+        self, server: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CHAMPI_STT_PROVIDER", "openai_whisper")
+        prov = _make_provider()
+        with (
+            tempfile.NamedTemporaryFile(suffix=".wav") as f,
+            patch("champi_stt.get_provider", return_value=prov) as mock_get,
+        ):
+            await server.call_tool("transcribe_audio", {"audio_path": f.name})
+        mock_get.assert_called_with("openai_whisper")
+
+    @pytest.mark.asyncio
+    async def test_explicit_provider_overrides_env_var(
+        self, server: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CHAMPI_STT_PROVIDER", "openai_whisper")
+        prov = _make_provider()
+        with (
+            tempfile.NamedTemporaryFile(suffix=".wav") as f,
+            patch("champi_stt.get_provider", return_value=prov) as mock_get,
+        ):
+            await server.call_tool(
+                "transcribe_audio",
+                {"audio_path": f.name, "provider": "whisperlive"},
+            )
+        mock_get.assert_called_with("whisperlive")
+
+
+# ---------------------------------------------------------------------------
+# Tool: detect_language
+# ---------------------------------------------------------------------------
+
+
+class TestDetectLanguageTool:
+    @pytest.mark.asyncio
+    async def test_missing_file_returns_error_dict(self, server: Any) -> None:
+        result = _raw(
+            await server.call_tool(
+                "detect_language", {"audio_path": "/no/such/file.wav"}
+            )
+        )
+        assert result["error"] is True
+
+    @pytest.mark.asyncio
+    async def test_missing_file_error_type_is_file_not_found(self, server: Any) -> None:
+        result = _raw(
+            await server.call_tool(
+                "detect_language", {"audio_path": "/no/such/file.wav"}
+            )
+        )
+        assert result["error_type"] == "FileNotFoundError"
+
+    @pytest.mark.asyncio
+    async def test_missing_file_error_message_contains_path(self, server: Any) -> None:
+        result = _raw(
+            await server.call_tool(
+                "detect_language", {"audio_path": "/no/such/file.wav"}
+            )
+        )
+        assert "/no/such/file.wav" in result["error_message"]
+
+    @pytest.mark.asyncio
+    async def test_returns_language_code(self, server: Any) -> None:
+        prov = _make_provider(detect_result=("fr", 0.87, []))
+        with (
+            tempfile.NamedTemporaryFile(suffix=".wav") as f,
+            patch("champi_stt.get_provider", return_value=prov),
+        ):
+            result = _raw(
+                await server.call_tool("detect_language", {"audio_path": f.name})
+            )
+        assert result["language"] == "fr"
+
+    @pytest.mark.asyncio
+    async def test_returns_probability(self, server: Any) -> None:
+        prov = _make_provider(detect_result=("es", 0.75, []))
+        with (
+            tempfile.NamedTemporaryFile(suffix=".wav") as f,
+            patch("champi_stt.get_provider", return_value=prov),
+        ):
+            result = _raw(
+                await server.call_tool("detect_language", {"audio_path": f.name})
+            )
+        assert result["probability"] == pytest.approx(0.75)
+
+    @pytest.mark.asyncio
+    async def test_provider_exception_returns_error_dict(self, server: Any) -> None:
+        prov = _make_provider(detect_raises=RuntimeError("model not loaded"))
+        with (
+            tempfile.NamedTemporaryFile(suffix=".wav") as f,
+            patch("champi_stt.get_provider", return_value=prov),
+        ):
+            result = _raw(
+                await server.call_tool("detect_language", {"audio_path": f.name})
+            )
+        assert result["error"] is True
+        assert result["error_type"] == "RuntimeError"
+
+    @pytest.mark.asyncio
+    async def test_env_var_selects_provider(
+        self, server: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CHAMPI_STT_PROVIDER", "openai_whisper")
+        prov = _make_provider()
+        with (
+            tempfile.NamedTemporaryFile(suffix=".wav") as f,
+            patch("champi_stt.get_provider", return_value=prov) as mock_get,
+        ):
+            await server.call_tool("detect_language", {"audio_path": f.name})
+        mock_get.assert_called_with("openai_whisper")
+
+    @pytest.mark.asyncio
+    async def test_explicit_provider_overrides_env_var(
+        self, server: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CHAMPI_STT_PROVIDER", "openai_whisper")
+        prov = _make_provider()
+        with (
+            tempfile.NamedTemporaryFile(suffix=".wav") as f,
+            patch("champi_stt.get_provider", return_value=prov) as mock_get,
+        ):
+            await server.call_tool(
+                "detect_language",
+                {"audio_path": f.name, "provider": "whisperlive"},
+            )
+        mock_get.assert_called_with("whisperlive")


### PR DESCRIPTION
## Summary

- Adds `tests/test_mcp/test_server.py`: spawns `champi-stt-mcp` via the mcp library's `stdio_client` + `ClientSession`, completes the full JSON-RPC initialize handshake, and asserts `serverInfo`, `protocolVersion`, `capabilities`, and the four registered tool names. Server is spawned once per test class to keep CI time reasonable.
- Adds `tests/test_mcp/test_cli.py`: exercises `champi-stt mcp serve` via Click's `CliRunner` with mocked `main()`, covering help output, argument forwarding (transport/host/port), input validation, the MCP-unavailable error path, and clean startup.
- Both files run under the default `pytest` invocation — no special flags, no audio hardware required.

## Implementation note

The issue spec mentions raw `subprocess.Popen` + manual JSON-RPC framing. In practice the MCP stdio transport runs on `anyio` async streams (`anyio.open_process`), making raw pipe I/O unreliable. Using the mcp library's own `stdio_client` gives the same end-to-end coverage while using the same protocol framing a real MCP host would use.

## Test plan

- [ ] `uv run python -m pytest tests/test_mcp/ -v` → 85 passed, 0 failed
- [ ] `uv run ruff check tests/test_mcp/test_server.py tests/test_mcp/test_cli.py` → all checks passed
- [ ] `uv run python -m mypy tests/test_mcp/test_server.py tests/test_mcp/test_cli.py --ignore-missing-imports` → success

Closes #57