### PR TITLE
docs(readme): add MCP server section and polish mcp serve --help

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,73 @@ export CHAMPI_LOG_LEVEL="INFO"                            # Logging level
 
 ---
 
+## 🤖 MCP Server
+
+Champi STT exposes its transcription tools over the
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/), letting
+LLM hosts such as Claude Desktop call them directly.
+
+### Install
+
+```bash
+pip install 'champi-stt[mcp]'
+```
+
+### Start
+
+```bash
+champi-stt mcp serve
+```
+
+Run `champi-stt mcp serve --help` to see all options including SSE transport.
+
+### Claude Desktop configuration
+
+Add a server entry to your `claude_desktop_config.json`:
+
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "champi-stt": {
+      "command": "champi-stt-mcp"
+    }
+  }
+}
+```
+
+To select a non-default STT provider, pass the `CHAMPI_STT_PROVIDER` environment variable:
+
+```json
+{
+  "mcpServers": {
+    "champi-stt": {
+      "command": "champi-stt-mcp",
+      "env": {
+        "CHAMPI_STT_PROVIDER": "whisperlive"
+      }
+    }
+  }
+}
+```
+
+After editing the file, restart Claude Desktop for the change to take effect.
+
+For development use from a source checkout, see [docs/mcp-integration.md](docs/mcp-integration.md).
+
+### Available tools
+
+| Tool | Description |
+|---|---|
+| `list_providers` | Return the names of all registered STT providers |
+| `get_provider_status` | Return health and model information for a named provider |
+| `transcribe_audio` | Transcribe a local audio file and return the transcript text |
+| `detect_language` | Detect the spoken language in a local audio file |
+
+---
+
 ## 📖 Documentation
 
 ### Architecture

--- a/src/champi_stt/mcp/server.py
+++ b/src/champi_stt/mcp/server.py
@@ -132,7 +132,9 @@ def create_mcp_server() -> Any:
         if not path.exists():
             return f"error: audio file not found: {audio_path}"
 
-        effective = provider or os.environ.get("CHAMPI_STT_PROVIDER") or _DEFAULT_PROVIDER
+        effective = (
+            provider or os.environ.get("CHAMPI_STT_PROVIDER") or _DEFAULT_PROVIDER
+        )
         try:
             p = await _get_provider(effective)
             result = await p.transcribe(str(path), language=language)
@@ -164,7 +166,9 @@ def create_mcp_server() -> Any:
                 "error_message": f"audio file not found: {audio_path}",
             }
 
-        effective = provider or os.environ.get("CHAMPI_STT_PROVIDER") or _DEFAULT_PROVIDER
+        effective = (
+            provider or os.environ.get("CHAMPI_STT_PROVIDER") or _DEFAULT_PROVIDER
+        )
         try:
             p = await _get_provider(effective)
             lang_code, probability, _all = await p.detect_language(str(path))


### PR DESCRIPTION
## Summary

- Adds a dedicated **MCP Server** section to `README.md` (after Quick Start) covering install (`pip install 'champi-stt[mcp]'`), start, Claude Desktop config snippet, `CHAMPI_STT_PROVIDER` env var, and a tools table
- Polishes `champi-stt mcp serve --help`: clearer option descriptions, expanded docstring explaining stdio vs sse behaviour, `CHAMPI_STT_PROVIDER` surfaced in the help output
- Fixes a pre-existing UP037 ruff violation in `mcp/server.py` (quoted return type annotation)

## Test plan

- [ ] `champi-stt mcp serve --help` output reviewed — all options have descriptive text, defaults shown, no TODO/placeholder strings
- [ ] README MCP section renders correctly in GitHub preview
- [ ] `ruff check src/` passes
- [ ] `ruff format --check src/` passes
- [ ] All existing tests pass (`pytest tests/`)

Closes #64