### PR TITLE
fix(ci): remove paths-ignore from release workflow tag trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - 'CHANGELOG.md'
-      - 'pyproject.toml'
     tags:
       - 'v*'
 


### PR DESCRIPTION
## Summary
- Removes `paths-ignore` from the `on.push` trigger — GitHub Actions does not allow `paths-ignore` alongside a `tags` filter in the same push event, causing a workflow startup failure on the v1.0.0 tag push.

## Test plan
- [ ] Re-tag v1.0.0 after merge to verify the `publish` job runs cleanly

Closes #82