### PR TITLE
fix(deps): embed champi-signals wheel URL in package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     # Event system
     "blinker>=1.9.0",
     "awaitlet>=0.0.1",
-    "champi-signals",
+    "champi-signals @ https://github.com/champi-ai/champi-signals/releases/download/v0.1.0/champi_signals-0.1.0-py3-none-any.whl",
     # Logging
     "loguru",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -595,7 +595,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "champi-stt"
-version = "1.0.2"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Replace bare `champi-signals` dependency with PEP 508 direct URL reference
- The URL is now embedded in the wheel's `METADATA` file, making it resolvable by any tool (`pip`, `uvx`, `uv`) without requiring access to the project's `[tool.uv.sources]` (which is dev-only)
- Fixes `uvx --from <champi-stt-wheel> champi-stt mcp serve` failing because `champi-signals` was not resolvable from PyPI

## Test plan

- [ ] Build wheel and run: `uvx --from <wheel-url> champi-stt mcp serve` — should start without dependency resolution errors
- [ ] CI passes