### PR TITLE
fix(mcp): respect CHAMPI_STT_PROVIDER in mic tools

### DIFF
--- a/src/champi_stt/mcp/mic_tools.py
+++ b/src/champi_stt/mcp/mic_tools.py
@@ -17,6 +17,8 @@ import soundfile as sf
 from champi_stt.core.response import TranscriptionResponse
 from champi_stt.factory import get_provider
 
+_DEFAULT_PROVIDER = "whisperlive"
+
 
 def _check_sounddevice() -> None:
     """Verify that sounddevice and its PortAudio backend are available.
@@ -75,13 +77,15 @@ async def _audio_to_text(
         audio_array: Captured audio samples as a numpy int16 array.
         sample_rate: Sample rate of the audio in Hz.
         language: BCP-47 language code hint, or None for auto-detect.
-        provider_name: Provider key (e.g. ``"whisperlive"``), or None to use
-            the default (``"whisperlive"``).
+        provider_name: Provider key (e.g. ``"whisperlive"``), or None to fall
+            back to the ``CHAMPI_STT_PROVIDER`` env var, then ``"whisperlive"``.
 
     Returns:
         Transcription text string.
     """
-    effective_provider = provider_name or "whisperlive"
+    effective_provider = (
+        provider_name or os.environ.get("CHAMPI_STT_PROVIDER") or _DEFAULT_PROVIDER
+    )
     loop = asyncio.get_event_loop()
 
     with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:

--- a/tests/test_mcp/test_mic_tools.py
+++ b/tests/test_mcp/test_mic_tools.py
@@ -151,6 +151,38 @@ class TestAudioToText:
         mock_get.assert_called_once_with("whisperlive")
 
     @pytest.mark.asyncio
+    async def test_uses_champi_stt_provider_env_var_when_provider_name_is_none(
+        self,
+    ) -> None:
+        import champi_stt.mcp.mic_tools as mic
+
+        prov = _make_provider()
+        with (
+            patch(
+                "champi_stt.mcp.mic_tools.get_provider", return_value=prov
+            ) as mock_get,
+            patch("champi_stt.mcp.mic_tools.sf.write"),
+            patch.dict(os.environ, {"CHAMPI_STT_PROVIDER": "openai_whisper"}),
+        ):
+            await mic._audio_to_text(self._make_audio(), 16000, None, None)
+        mock_get.assert_called_once_with("openai_whisper")
+
+    @pytest.mark.asyncio
+    async def test_explicit_provider_name_overrides_env_var(self) -> None:
+        import champi_stt.mcp.mic_tools as mic
+
+        prov = _make_provider()
+        with (
+            patch(
+                "champi_stt.mcp.mic_tools.get_provider", return_value=prov
+            ) as mock_get,
+            patch("champi_stt.mcp.mic_tools.sf.write"),
+            patch.dict(os.environ, {"CHAMPI_STT_PROVIDER": "openai_whisper"}),
+        ):
+            await mic._audio_to_text(self._make_audio(), 16000, None, "whisperlive")
+        mock_get.assert_called_once_with("whisperlive")
+
+    @pytest.mark.asyncio
     async def test_uses_specified_provider_name(self) -> None:
         import champi_stt.mcp.mic_tools as mic
 


### PR DESCRIPTION
## Summary

- `_audio_to_text` in `mic_tools.py` always fell back to `"whisperlive"` when no explicit provider was passed — it never consulted `CHAMPI_STT_PROVIDER`
- Added module-level `_DEFAULT_PROVIDER = "whisperlive"` constant (mirrors `server.py`)
- Changed the fallback chain to: `provider_name or os.environ.get("CHAMPI_STT_PROVIDER") or _DEFAULT_PROVIDER`, consistent with `transcribe_audio` and `detect_language` in `server.py`

## Tests

Two new tests added in `TestAudioToText`:
- `test_uses_champi_stt_provider_env_var_when_provider_name_is_none`
- `test_explicit_provider_name_overrides_env_var`

All 780 tests pass.

Closes #103