### PR TITLE
fix(whisperlive): detect broken model cache symlinks with actionable error

### DIFF
--- a/src/champi_stt/providers/whisperlive/provider.py
+++ b/src/champi_stt/providers/whisperlive/provider.py
@@ -12,6 +12,7 @@ import contextlib
 import dataclasses
 
 # import logging - replaced with loguru
+import os
 import queue
 import tempfile
 from pathlib import Path
@@ -135,10 +136,13 @@ class WhisperLiveSTTProvider:
             # 1. Validate directories FIRST
             self.validate_directories()
 
-            # 2. Initialize transcriber (which initializes model manager)
+            # 2. Check model cache for broken symlinks before attempting model load
+            self._check_model_cache(self.config.model_size, self.config.cache_dir)
+
+            # 3. Initialize transcriber (which initializes model manager)
             self.transcriber = WhisperLiveTranscriber(self.config)
 
-            # 3. Emit pre-loading signal
+            # 4. Emit pre-loading signal
             self.Meta.signal_manager.model.send(
                 self,
                 event_type="model",
@@ -149,7 +153,7 @@ class WhisperLiveSTTProvider:
                 },
             )
 
-            # 4. Initialize model (with caching/device detection)
+            # 5. Initialize model (with caching/device detection)
             await self.transcriber.initialize()
 
             self._initialized = True
@@ -466,6 +470,43 @@ class WhisperLiveSTTProvider:
         except Exception as e:
             logger.error(f"Failed to create directories: {e}")
             raise WhisperFileError(f"Directory creation failed: {e}") from e
+
+    def _check_model_cache(self, model_name: str, cache_dir: str) -> None:
+        """Check the HuggingFace model cache for broken symlinks.
+
+        The faster-whisper cache follows the HuggingFace convention of storing
+        model blobs alongside relative symlinks in snapshot directories.  If the
+        cache was partially downloaded or relocated the symlinks become dangling,
+        causing a confusing FileNotFoundError deep inside the model loader.
+
+        Args:
+            model_name: The model size string (e.g. ``"base"``, ``"small"``).
+            cache_dir: Path to the cache root directory (tilde expansion is applied).
+
+        Raises:
+            WhisperInitializationError: If one or more broken symlinks are found
+                inside the model cache directory, with an actionable remediation
+                command.
+        """
+        expanded = os.path.expanduser(cache_dir)
+        model_dir = Path(expanded) / f"models--Systran--faster-whisper-{model_name}"
+
+        if not model_dir.exists():
+            return
+
+        broken = [
+            entry
+            for entry in model_dir.rglob("*")
+            if entry.is_symlink() and not entry.exists()
+        ]
+
+        if broken:
+            raise WhisperInitializationError(
+                f"Broken symlinks found in the model cache for '{model_name}'. "
+                f"The cache is corrupted or was partially downloaded. "
+                f"Remove it and let the model re-download on next run:\n"
+                f"  rm -rf {model_dir}"
+            )
 
     def get_default_cache_dir(self) -> str:
         """Get platform-appropriate cache directory"""

--- a/tests/test_whisperlive_provider.py
+++ b/tests/test_whisperlive_provider.py
@@ -1511,3 +1511,58 @@ class TestTranscriberNumpyPath:
         )
 
         assert result["text"] == ""
+
+
+class TestCheckModelCache:
+    """Tests for WhisperLiveProvider._check_model_cache()."""
+
+    @pytest.fixture(autouse=True)
+    def reset_singleton(self):
+        WhisperLiveProvider._instance = None
+        yield
+        WhisperLiveProvider._instance = None
+
+    def _make_provider(self, tmp_path):
+        config = WhisperLiveConfig(cache_dir=str(tmp_path))
+        return WhisperLiveProvider(config=config)
+
+    def test_missing_model_dir_does_not_raise(self, tmp_path):
+        """No error when the model has never been downloaded."""
+        provider = self._make_provider(tmp_path)
+        # model dir does not exist — should be a silent no-op
+        provider._check_model_cache("base", str(tmp_path))
+
+    def test_valid_cache_without_broken_symlinks_does_not_raise(self, tmp_path):
+        """A complete cache with intact symlinks passes the check."""
+        model_dir = tmp_path / "models--Systran--faster-whisper-base"
+        blobs = model_dir / "blobs"
+        blobs.mkdir(parents=True)
+        blob_file = blobs / "abc123"
+        blob_file.write_text("fake blob")
+
+        snapshot_dir = model_dir / "snapshots" / "rev1"
+        snapshot_dir.mkdir(parents=True)
+        link = snapshot_dir / "config.json"
+        link.symlink_to(blob_file)
+
+        provider = self._make_provider(tmp_path)
+        # Valid symlink — must not raise
+        provider._check_model_cache("base", str(tmp_path))
+
+    def test_broken_symlink_raises_whisperinitializationerror(self, tmp_path):
+        """A dangling symlink causes WhisperInitializationError with a helpful message."""
+        model_dir = tmp_path / "models--Systran--faster-whisper-base"
+        snapshot_dir = model_dir / "snapshots" / "rev1"
+        snapshot_dir.mkdir(parents=True)
+        broken_link = snapshot_dir / "config.json"
+        broken_link.symlink_to("/nonexistent/target/blob_abc")
+
+        provider = self._make_provider(tmp_path)
+        with pytest.raises(WhisperInitializationError) as exc_info:
+            provider._check_model_cache("base", str(tmp_path))
+
+        message = str(exc_info.value)
+        assert "broken symlinks" in message.lower()
+        assert "base" in message
+        assert "rm -rf" in message
+        assert str(model_dir) in message


### PR DESCRIPTION
## Summary

- Adds `_check_model_cache(model_name, cache_dir)` to `WhisperLiveSTTProvider` that walks the HuggingFace snapshot directory and detects dangling symlinks before model loading begins
- Raises `WhisperInitializationError` with a concrete `rm -rf <path>` remediation command when broken symlinks are found
- Called inside `initialize()` immediately after `validate_directories()`, so the clear error surfaces before the opaque `FileNotFoundError` from the model loader

## Test plan

- `test_missing_model_dir_does_not_raise` — model not yet downloaded is a silent no-op
- `test_valid_cache_without_broken_symlinks_does_not_raise` — intact symlink passes the check
- `test_broken_symlink_raises_whisperinitializationerror` — dangling symlink produces `WhisperInitializationError` with "broken symlinks", the model name, `rm -rf`, and the actual path in the message

All 781 tests pass, coverage 48.37% (threshold 48%).

Closes #105