### PR TITLE
feat(providers): add Kokoro STT provider skeleton

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,11 @@ mcp = [
     "mcp[cli]>=1.0,<2.0",
 ]
 
+# Kokoro local STT model
+kokoro = [
+    "kokoro>=0.9",
+]
+
 # Speaker diarization via pyannote.audio
 diarization = [
     "pyannote.audio>=3.1.0",
@@ -114,7 +119,7 @@ diarization = [
 
 # All optional extras
 all = [
-    "champi-stt[torch,imgui,nlp,wakeword,vosk,assemblyai,diarization,webui,mcp]",
+    "champi-stt[torch,imgui,nlp,wakeword,vosk,assemblyai,diarization,webui,mcp,kokoro]",
 ]
 
 # Documentation

--- a/src/champi_stt/factory.py
+++ b/src/champi_stt/factory.py
@@ -8,7 +8,13 @@ from typing import Any
 
 from champi_stt.core.base_provider import BaseSTTProvider
 
-_SUPPORTED_PROVIDERS = ["whisperlive", "openai_whisper", "deepgram", "assemblyai"]
+_SUPPORTED_PROVIDERS = [
+    "whisperlive",
+    "openai_whisper",
+    "deepgram",
+    "assemblyai",
+    "kokoro",
+]
 
 
 def get_provider(
@@ -20,7 +26,7 @@ def get_provider(
     Factory function to create STT providers.
 
     Args:
-        provider_type: Provider key — "whisperlive", "openai_whisper", or "deepgram"
+        provider_type: Provider key — "whisperlive", "openai_whisper", "deepgram", "assemblyai", or "kokoro"
         config: Pre-built provider config object (optional)
         **config_kwargs: Config fields forwarded to the config constructor
 
@@ -76,6 +82,17 @@ def get_provider(
                 else AssemblyAIConfig.from_env()
             )
         return AssemblyAIProvider(config=config)
+
+    if provider_type == "kokoro":
+        from champi_stt.providers.kokoro import KokoroConfig, KokoroSTTProvider
+
+        if config is None:
+            config = (
+                KokoroConfig(**config_kwargs)
+                if config_kwargs
+                else KokoroConfig.from_env()
+            )
+        return KokoroSTTProvider(config=config)
 
     raise ValueError(
         f"Unknown provider type: {provider_type!r}. "

--- a/src/champi_stt/providers/kokoro/__init__.py
+++ b/src/champi_stt/providers/kokoro/__init__.py
@@ -1,0 +1,17 @@
+"""Kokoro local STT provider."""
+
+from champi_stt.providers.kokoro.config import KokoroConfig
+from champi_stt.providers.kokoro.exceptions import (
+    KokoroError,
+    KokoroNotInstalledError,
+    KokoroTranscriptionError,
+)
+from champi_stt.providers.kokoro.provider import KokoroSTTProvider
+
+__all__ = [
+    "KokoroConfig",
+    "KokoroError",
+    "KokoroNotInstalledError",
+    "KokoroSTTProvider",
+    "KokoroTranscriptionError",
+]

--- a/src/champi_stt/providers/kokoro/config.py
+++ b/src/champi_stt/providers/kokoro/config.py
@@ -1,0 +1,36 @@
+"""Configuration for the Kokoro STT provider."""
+
+import os
+from dataclasses import dataclass
+
+from champi_stt.core.base_config import BaseSTTConfig
+
+
+@dataclass
+class KokoroConfig(BaseSTTConfig):
+    """Configuration for the Kokoro local STT provider."""
+
+    # Model repository ID used by kokoro at initialisation time
+    model_id: str = "hexgrad/Kokoro-82M"
+
+    # BCP-47 language code passed to the kokoro pipeline.
+    # kokoro uses single-letter codes internally; 'a' = American English.
+    lang_code: str = "a"
+
+    # Inference device: "cpu" or "cuda"
+    device: str = "cpu"
+
+    @classmethod
+    def from_env(cls) -> "KokoroConfig":
+        """Create a KokoroConfig from environment variables.
+
+        Reads:
+          KOKORO_MODEL_ID  — model repository ID (default: hexgrad/Kokoro-82M)
+          KOKORO_LANG_CODE — language code (default: a)
+          KOKORO_DEVICE    — inference device (default: cpu)
+        """
+        return cls(
+            model_id=os.environ.get("KOKORO_MODEL_ID", "hexgrad/Kokoro-82M"),
+            lang_code=os.environ.get("KOKORO_LANG_CODE", "a"),
+            device=os.environ.get("KOKORO_DEVICE", "cpu"),
+        )

--- a/src/champi_stt/providers/kokoro/exceptions.py
+++ b/src/champi_stt/providers/kokoro/exceptions.py
@@ -1,0 +1,13 @@
+"""Kokoro provider exceptions."""
+
+
+class KokoroError(Exception):
+    """Base exception for Kokoro provider errors."""
+
+
+class KokoroNotInstalledError(KokoroError):
+    """Raised when the kokoro package is not installed."""
+
+
+class KokoroTranscriptionError(KokoroError):
+    """Raised when the Kokoro pipeline fails to transcribe audio."""

--- a/src/champi_stt/providers/kokoro/provider.py
+++ b/src/champi_stt/providers/kokoro/provider.py
@@ -1,0 +1,223 @@
+"""Kokoro local STT provider.
+
+Kokoro (https://github.com/hexgrad/kokoro) is a lightweight, fully-offline
+speech model.  Install the optional extra before use::
+
+    pip install "champi-stt[kokoro]"
+
+The provider calls ``KPipeline.recognize()`` to convert raw audio to text and
+returns a standard :class:`~champi_stt.core.response.TranscriptionResponse`.
+"""
+
+import asyncio
+import io
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from loguru import logger
+
+from champi_stt.core.base_provider import BaseSTTProvider
+from champi_stt.core.response import TranscriptionResponse
+from champi_stt.providers.kokoro.config import KokoroConfig
+from champi_stt.providers.kokoro.exceptions import (
+    KokoroNotInstalledError,
+    KokoroTranscriptionError,
+)
+
+try:
+    from kokoro import KPipeline
+
+    KOKORO_AVAILABLE = True
+except ImportError:
+    KPipeline = None  # type: ignore[assignment,misc]
+    KOKORO_AVAILABLE = False
+
+try:
+    import soundfile as sf
+
+    SOUNDFILE_AVAILABLE = True
+except ImportError:
+    sf = None  # type: ignore[assignment]
+    SOUNDFILE_AVAILABLE = False
+
+
+class KokoroSTTProvider(BaseSTTProvider):
+    """Local STT provider backed by the Kokoro speech model.
+
+    Kokoro runs entirely offline; no API key or network connection is required
+    after the initial package install.
+    """
+
+    name = "Kokoro"
+
+    def __init__(self, config: KokoroConfig) -> None:
+        super().__init__(config)
+        self.config: KokoroConfig = config
+        self._pipeline: Any = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+
+    async def initialize(self) -> None:
+        """Load the Kokoro pipeline.
+
+        Raises:
+            KokoroNotInstalledError: If the ``kokoro`` package is not installed.
+        """
+        if self._initialized:
+            return
+
+        if not KOKORO_AVAILABLE:
+            raise KokoroNotInstalledError(
+                "The kokoro package is required for KokoroSTTProvider. "
+                "Install it with: pip install 'champi-stt[kokoro]'"
+            )
+
+        loop = asyncio.get_running_loop()
+        self._pipeline = await loop.run_in_executor(
+            None,
+            lambda: KPipeline(
+                lang_code=self.config.lang_code,
+                device=self.config.device,
+                repo_id=self.config.model_id,
+            ),
+        )
+        self._initialized = True
+        logger.info(
+            "Kokoro provider initialized (model={}, device={})",
+            self.config.model_id,
+            self.config.device,
+        )
+
+    async def shutdown(self) -> None:
+        """Release the Kokoro pipeline and free resources."""
+        self._pipeline = None
+        self._initialized = False
+        logger.info("Kokoro provider shut down")
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def is_loaded(self) -> bool:
+        """``True`` when the pipeline is ready to transcribe."""
+        return self._initialized
+
+    @property
+    def is_initialized(self) -> bool:
+        """``True`` when the pipeline is ready to transcribe."""
+        return self._initialized
+
+    # ------------------------------------------------------------------
+    # Transcription
+
+    async def transcribe(
+        self,
+        audio_data: bytes | np.ndarray | str | Path,
+        language: str | None = None,
+        **kwargs: Any,
+    ) -> TranscriptionResponse:
+        """Transcribe audio using the local Kokoro pipeline.
+
+        Args:
+            audio_data: Audio as raw bytes, a NumPy array (float32 or int16),
+                        or a file path (str / Path).
+            language:   Language hint forwarded to the pipeline.  When ``None``
+                        the language code from :attr:`config` is used.
+            **kwargs:   Reserved for future provider-specific options.
+
+        Returns:
+            :class:`~champi_stt.core.response.TranscriptionResponse`
+
+        Raises:
+            RuntimeError:            If the provider has not been initialized.
+            KokoroTranscriptionError: If the Kokoro pipeline raises an error.
+        """
+        if not self._initialized:
+            raise RuntimeError("Provider not initialized — call initialize() first")
+
+        wav_bytes = await self._to_wav_bytes(audio_data)
+        lang = language or self.config.lang_code
+
+        start = time.perf_counter()
+        loop = asyncio.get_running_loop()
+        try:
+            text = await loop.run_in_executor(
+                None, self._run_recognize, wav_bytes, lang
+            )
+        except Exception as exc:
+            raise KokoroTranscriptionError(
+                f"Kokoro transcription failed: {exc}"
+            ) from exc
+
+        processing_time = time.perf_counter() - start
+        return TranscriptionResponse(
+            text=text.strip(),
+            language=lang,
+            processing_time=processing_time,
+        )
+
+    # ------------------------------------------------------------------
+    # Context-manager support
+
+    async def __aenter__(self) -> "KokoroSTTProvider":
+        await self.initialize()
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        await self.shutdown()
+
+    # ------------------------------------------------------------------
+    # Model info
+
+    async def get_model_info(self) -> dict[str, Any]:
+        """Return provider metadata."""
+        return {
+            "status": "loaded" if self._initialized else "not_initialized",
+            "provider": "kokoro",
+            "model_id": self.config.model_id,
+            "device": self.config.device,
+            "lang_code": self.config.lang_code,
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+
+    def _run_recognize(self, wav_bytes: bytes, lang: str) -> str:
+        """Synchronous call into the Kokoro pipeline (runs in a thread pool)."""
+        return self._pipeline.recognize(wav_bytes, lang=lang)  # type: ignore[union-attr]
+
+    async def _to_wav_bytes(self, audio: bytes | np.ndarray | str | Path) -> bytes:
+        """Convert any supported audio input to WAV bytes."""
+        if isinstance(audio, Path):
+            audio = str(audio)
+
+        if isinstance(audio, str):
+            return Path(audio).read_bytes()
+
+        if isinstance(audio, bytes):
+            return audio
+
+        if isinstance(audio, np.ndarray):
+            if not SOUNDFILE_AVAILABLE:
+                raise ImportError(
+                    "soundfile is required for NumPy array input. "
+                    "Install with: pip install soundfile"
+                )
+            buf = io.BytesIO()
+            if np.issubdtype(audio.dtype, np.floating):
+                data = (audio * 32767).clip(-32768, 32767).astype(np.int16)
+            else:
+                data = audio.astype(np.int16)
+            sf.write(
+                buf,
+                data,
+                samplerate=self.config.sample_rate,
+                format="WAV",
+                subtype="PCM_16",
+            )
+            return buf.getvalue()
+
+        raise TypeError(f"Unsupported audio type: {type(audio)}")

--- a/tests/test_kokoro_provider.py
+++ b/tests/test_kokoro_provider.py
@@ -1,0 +1,325 @@
+"""Tests for the Kokoro STT provider."""
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from champi_stt.core.response import TranscriptionResponse
+from champi_stt.providers.kokoro.config import KokoroConfig
+from champi_stt.providers.kokoro.exceptions import (
+    KokoroNotInstalledError,
+    KokoroTranscriptionError,
+)
+from champi_stt.providers.kokoro.provider import KokoroSTTProvider
+
+
+@pytest.fixture
+def config():
+    return KokoroConfig(lang_code="a", device="cpu", model_id="hexgrad/Kokoro-82M")
+
+
+@pytest.fixture
+def provider(config):
+    return KokoroSTTProvider(config)
+
+
+# ---------------------------------------------------------------------------
+# Config
+
+
+class TestKokoroConfig:
+    def test_defaults(self):
+        cfg = KokoroConfig()
+        assert cfg.model_id == "hexgrad/Kokoro-82M"
+        assert cfg.lang_code == "a"
+        assert cfg.device == "cpu"
+
+    def test_from_env(self, monkeypatch):
+        monkeypatch.setenv("KOKORO_MODEL_ID", "hexgrad/Kokoro-Small")
+        monkeypatch.setenv("KOKORO_LANG_CODE", "b")
+        monkeypatch.setenv("KOKORO_DEVICE", "cuda")
+        cfg = KokoroConfig.from_env()
+        assert cfg.model_id == "hexgrad/Kokoro-Small"
+        assert cfg.lang_code == "b"
+        assert cfg.device == "cuda"
+
+    def test_from_env_defaults(self, monkeypatch):
+        monkeypatch.delenv("KOKORO_MODEL_ID", raising=False)
+        monkeypatch.delenv("KOKORO_LANG_CODE", raising=False)
+        monkeypatch.delenv("KOKORO_DEVICE", raising=False)
+        cfg = KokoroConfig.from_env()
+        assert cfg.model_id == "hexgrad/Kokoro-82M"
+        assert cfg.lang_code == "a"
+        assert cfg.device == "cpu"
+
+
+# ---------------------------------------------------------------------------
+# Provider initialisation
+
+
+class TestKokoroSTTProviderInit:
+    def test_name(self, provider):
+        assert provider.name == "Kokoro"
+
+    def test_not_initialized_at_construction(self, provider):
+        assert not provider.is_initialized
+        assert not provider.is_loaded
+
+    @pytest.mark.asyncio
+    async def test_initialize_raises_when_kokoro_missing(self, config):
+        p = KokoroSTTProvider(config)
+        with (
+            patch("champi_stt.providers.kokoro.provider.KOKORO_AVAILABLE", False),
+            pytest.raises(KokoroNotInstalledError, match="kokoro package is required"),
+        ):
+            await p.initialize()
+
+    @pytest.mark.asyncio
+    async def test_initialize_success(self, config):
+        mock_pipeline = MagicMock()
+        mock_kpipeline_cls = MagicMock(return_value=mock_pipeline)
+
+        p = KokoroSTTProvider(config)
+        with (
+            patch("champi_stt.providers.kokoro.provider.KOKORO_AVAILABLE", True),
+            patch("champi_stt.providers.kokoro.provider.KPipeline", mock_kpipeline_cls),
+        ):
+            await p.initialize()
+
+        assert p.is_initialized
+        mock_kpipeline_cls.assert_called_once_with(
+            lang_code="a",
+            device="cpu",
+            repo_id="hexgrad/Kokoro-82M",
+        )
+
+    @pytest.mark.asyncio
+    async def test_initialize_idempotent(self, config):
+        mock_pipeline = MagicMock()
+        mock_kpipeline_cls = MagicMock(return_value=mock_pipeline)
+
+        p = KokoroSTTProvider(config)
+        with (
+            patch("champi_stt.providers.kokoro.provider.KOKORO_AVAILABLE", True),
+            patch("champi_stt.providers.kokoro.provider.KPipeline", mock_kpipeline_cls),
+        ):
+            await p.initialize()
+            await p.initialize()
+
+        assert mock_kpipeline_cls.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_shutdown(self, config):
+        mock_pipeline = MagicMock()
+        mock_kpipeline_cls = MagicMock(return_value=mock_pipeline)
+
+        p = KokoroSTTProvider(config)
+        with (
+            patch("champi_stt.providers.kokoro.provider.KOKORO_AVAILABLE", True),
+            patch("champi_stt.providers.kokoro.provider.KPipeline", mock_kpipeline_cls),
+        ):
+            await p.initialize()
+        assert p.is_initialized
+
+        await p.shutdown()
+        assert not p.is_initialized
+        assert p._pipeline is None
+
+
+# ---------------------------------------------------------------------------
+# Transcription
+
+
+class TestKokoroSTTProviderTranscribe:
+    def _make_initialized_provider(self, config):
+        p = KokoroSTTProvider(config)
+        mock_pipeline = MagicMock()
+        mock_pipeline.recognize.return_value = "hello kokoro"
+        p._pipeline = mock_pipeline
+        p._initialized = True
+        return p
+
+    @pytest.mark.asyncio
+    async def test_transcribe_not_initialized_raises(self, config):
+        p = KokoroSTTProvider(config)
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await p.transcribe(b"\x00" * 100)
+
+    @pytest.mark.asyncio
+    async def test_transcribe_bytes(self, config):
+        p = self._make_initialized_provider(config)
+        result = await p.transcribe(b"\x00" * 100)
+        assert isinstance(result, TranscriptionResponse)
+        assert result.text == "hello kokoro"
+        assert result.language == "a"
+
+    @pytest.mark.asyncio
+    async def test_transcribe_bytes_language_override(self, config):
+        p = self._make_initialized_provider(config)
+        result = await p.transcribe(b"\x00" * 100, language="en")
+        assert result.language == "en"
+        p._pipeline.recognize.assert_called_with(b"\x00" * 100, lang="en")
+
+    @pytest.mark.asyncio
+    async def test_transcribe_file_path_str(self, tmp_path, config):
+        audio_file = tmp_path / "audio.wav"
+        audio_file.write_bytes(b"RIFF\x00\x00\x00\x00WAVEfmt ")
+
+        p = self._make_initialized_provider(config)
+        result = await p.transcribe(str(audio_file))
+        assert isinstance(result, TranscriptionResponse)
+        assert result.text == "hello kokoro"
+
+    @pytest.mark.asyncio
+    async def test_transcribe_file_path_object(self, tmp_path, config):
+        audio_file = tmp_path / "audio.wav"
+        audio_file.write_bytes(b"RIFF\x00\x00\x00\x00WAVEfmt ")
+
+        p = self._make_initialized_provider(config)
+        result = await p.transcribe(audio_file)
+        assert isinstance(result, TranscriptionResponse)
+
+    @pytest.mark.asyncio
+    async def test_transcribe_numpy_float32(self, config):
+        import soundfile as sf_mod
+
+        audio = np.zeros(16000, dtype=np.float32)
+        p = self._make_initialized_provider(config)
+        with (
+            patch("champi_stt.providers.kokoro.provider.SOUNDFILE_AVAILABLE", True),
+            patch("champi_stt.providers.kokoro.provider.sf", sf_mod),
+        ):
+            result = await p.transcribe(audio)
+        assert isinstance(result, TranscriptionResponse)
+
+    @pytest.mark.asyncio
+    async def test_transcribe_numpy_int16(self, config):
+        import soundfile as sf_mod
+
+        audio = np.zeros(16000, dtype=np.int16)
+        p = self._make_initialized_provider(config)
+        with (
+            patch("champi_stt.providers.kokoro.provider.SOUNDFILE_AVAILABLE", True),
+            patch("champi_stt.providers.kokoro.provider.sf", sf_mod),
+        ):
+            result = await p.transcribe(audio)
+        assert isinstance(result, TranscriptionResponse)
+
+    @pytest.mark.asyncio
+    async def test_transcribe_numpy_no_soundfile(self, config):
+        audio = np.zeros(16000, dtype=np.float32)
+        p = self._make_initialized_provider(config)
+        with (
+            patch("champi_stt.providers.kokoro.provider.SOUNDFILE_AVAILABLE", False),
+            pytest.raises(ImportError, match="soundfile is required"),
+        ):
+            await p.transcribe(audio)
+
+    @pytest.mark.asyncio
+    async def test_transcribe_unsupported_type(self, config):
+        p = self._make_initialized_provider(config)
+        with pytest.raises(TypeError, match="Unsupported audio type"):
+            await p.transcribe(12345)  # type: ignore[arg-type]
+
+    @pytest.mark.asyncio
+    async def test_transcribe_pipeline_error_raises_kokoro_error(self, config):
+        p = self._make_initialized_provider(config)
+        p._pipeline.recognize.side_effect = RuntimeError("model crash")
+        with pytest.raises(KokoroTranscriptionError, match="model crash"):
+            await p.transcribe(b"\x00" * 100)
+
+    @pytest.mark.asyncio
+    async def test_transcribe_strips_whitespace(self, config):
+        p = self._make_initialized_provider(config)
+        p._pipeline.recognize.return_value = "  hello world  "
+        result = await p.transcribe(b"\x00" * 100)
+        assert result.text == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_transcribe_processing_time_positive(self, config):
+        p = self._make_initialized_provider(config)
+        result = await p.transcribe(b"\x00" * 100)
+        assert result.processing_time >= 0.0
+
+
+# ---------------------------------------------------------------------------
+# Context manager
+
+
+class TestKokoroSTTProviderContextManager:
+    @pytest.mark.asyncio
+    async def test_context_manager(self, config):
+        mock_pipeline = MagicMock()
+        mock_kpipeline_cls = MagicMock(return_value=mock_pipeline)
+
+        with (
+            patch("champi_stt.providers.kokoro.provider.KOKORO_AVAILABLE", True),
+            patch("champi_stt.providers.kokoro.provider.KPipeline", mock_kpipeline_cls),
+        ):
+            async with KokoroSTTProvider(config) as p:
+                assert p.is_initialized
+        assert not p.is_initialized
+
+
+# ---------------------------------------------------------------------------
+# Model info
+
+
+class TestKokoroSTTProviderModelInfo:
+    @pytest.mark.asyncio
+    async def test_get_model_info_not_initialized(self, provider):
+        info = await provider.get_model_info()
+        assert info["status"] == "not_initialized"
+        assert info["provider"] == "kokoro"
+        assert info["model_id"] == "hexgrad/Kokoro-82M"
+
+    @pytest.mark.asyncio
+    async def test_get_model_info_initialized(self, config):
+        mock_pipeline = MagicMock()
+        mock_kpipeline_cls = MagicMock(return_value=mock_pipeline)
+
+        p = KokoroSTTProvider(config)
+        with (
+            patch("champi_stt.providers.kokoro.provider.KOKORO_AVAILABLE", True),
+            patch("champi_stt.providers.kokoro.provider.KPipeline", mock_kpipeline_cls),
+        ):
+            await p.initialize()
+
+        info = await p.get_model_info()
+        assert info["status"] == "loaded"
+        assert info["device"] == "cpu"
+        assert info["lang_code"] == "a"
+
+
+# ---------------------------------------------------------------------------
+# Factory integration
+
+
+class TestKokoroFactory:
+    def test_list_providers_includes_kokoro(self):
+        from champi_stt.factory import list_providers
+
+        assert "kokoro" in list_providers()
+
+    def test_get_provider_kokoro_returns_provider(self):
+        from champi_stt.factory import get_provider
+
+        p = get_provider("kokoro")
+        assert isinstance(p, KokoroSTTProvider)
+        assert not p.is_initialized
+
+    def test_get_provider_kokoro_with_kwargs(self):
+        from champi_stt.factory import get_provider
+
+        p = get_provider("kokoro", lang_code="b", device="cuda")
+        assert isinstance(p, KokoroSTTProvider)
+        assert p.config.lang_code == "b"
+        assert p.config.device == "cuda"
+
+    def test_get_provider_kokoro_with_config(self, config):
+        from champi_stt.factory import get_provider
+
+        p = get_provider("kokoro", config=config)
+        assert isinstance(p, KokoroSTTProvider)
+        assert p.config is config

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "addict"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/ef/fd7649da8af11d93979831e8f1f8097e85e82d5bfeabc8c68b39175d8e75/addict-2.4.0.tar.gz", hash = "sha256:b3b2210e0e067a281f5646c8c5db92e99b7231ea8b0eb5f74dbdf9e259d4e494", size = 9186, upload-time = "2020-11-21T16:21:31.416Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/00/b08f23b7d7e1e14ce01419a467b583edbb93c6cdb8654e54a9cc579cd61f/addict-2.4.0-py3-none-any.whl", hash = "sha256:249bb56bbfd3cdc2a004ea0ff4c2b6ddc84d53bc2194761636eb314d5cfa5dfc", size = 3832, upload-time = "2020-11-21T16:21:29.588Z" },
+]
+
+[[package]]
 name = "aiofiles"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -595,7 +604,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "champi-stt"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -634,6 +643,7 @@ all = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "imgui-bundle" },
+    { name = "kokoro" },
     { name = "mcp", extra = ["cli"] },
     { name = "openwakeword" },
     { name = "pyannote-audio" },
@@ -684,6 +694,9 @@ imgui = [
     { name = "pyglm" },
     { name = "pygltflib" },
     { name = "pyopengl" },
+]
+kokoro = [
+    { name = "kokoro" },
 ]
 mcp = [
     { name = "mcp", extra = ["cli"] },
@@ -742,7 +755,7 @@ requires-dist = [
     { name = "blinker", specifier = ">=1.9.0" },
     { name = "build", marker = "extra == 'dev'" },
     { name = "champi-signals", url = "https://github.com/champi-ai/champi-signals/releases/download/v0.1.0/champi_signals-0.1.0-py3-none-any.whl" },
-    { name = "champi-stt", extras = ["torch", "imgui", "nlp", "wakeword", "vosk", "assemblyai", "diarization", "webui", "mcp"], marker = "extra == 'all'" },
+    { name = "champi-stt", extras = ["torch", "imgui", "nlp", "wakeword", "vosk", "assemblyai", "diarization", "webui", "mcp", "kokoro"], marker = "extra == 'all'" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "coverage", marker = "extra == 'test'" },
     { name = "ctranslate2" },
@@ -753,6 +766,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "httpx", marker = "extra == 'assemblyai'", specifier = ">=0.25.0" },
     { name = "imgui-bundle", marker = "extra == 'imgui'" },
+    { name = "kokoro", marker = "extra == 'kokoro'", specifier = ">=0.9" },
     { name = "librosa", specifier = ">=0.10.0" },
     { name = "loguru" },
     { name = "mcp", extras = ["cli"], marker = "extra == 'mcp'", specifier = ">=1.0,<2.0" },
@@ -805,7 +819,7 @@ requires-dist = [
     { name = "webrtcvad" },
     { name = "websockets", marker = "extra == 'assemblyai'", specifier = ">=12.0" },
 ]
-provides-extras = ["torch", "imgui", "nlp", "wakeword", "vosk", "assemblyai", "webui", "mcp", "diarization", "all", "docs", "dev", "test"]
+provides-extras = ["torch", "imgui", "nlp", "wakeword", "vosk", "assemblyai", "webui", "mcp", "kokoro", "diarization", "all", "docs", "dev", "test"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1109,6 +1123,22 @@ wheels = [
 ]
 
 [[package]]
+name = "csvw"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "isodate" },
+    { name = "python-dateutil" },
+    { name = "rfc3986" },
+    { name = "uritemplate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/a6/a8436f8f7b5578461a4e5c0dbc8341fe2596b703704cf0f5acd35953cc85/csvw-1.11.0.tar.gz", hash = "sha256:c156466fab3331861e0cf3cbe0c4538705800bfac98819149cd70ecbe6f152eb", size = 34812, upload-time = "2021-05-06T08:15:15.351Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/ae/afb43a6b88c4202d29e4ec7aca76633d8c530140f4f5a32ee762d07c4607/csvw-1.11.0-py2.py3-none-any.whl", hash = "sha256:243825391308f2568593415364868dda5e50f608fc2bb307fbd79d534af52fd5", size = 35198, upload-time = "2021-05-06T08:15:19.729Z" },
+]
+
+[[package]]
 name = "ctranslate2"
 version = "4.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1209,6 +1239,34 @@ nvrtc = [
 ]
 nvtx = [
     { name = "nvidia-nvtx-cu12", marker = "sys_platform == 'linux'" },
+]
+
+[[package]]
+name = "curated-tokenizers"
+version = "0.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/fa/b2d55f0d53c7c7f5dc0b6dbb48cc4344ee84fb572f23de28040bf2cde89d/curated-tokenizers-0.0.9.tar.gz", hash = "sha256:c93d47e54ab3528a6db2796eeb4bdce5d44e8226c671e42c2f23522ab1d0ce25", size = 2237055, upload-time = "2024-01-18T13:45:52.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/3e/c10474a21ed0166f94cebb46fe96cf07fdf7f399d84e6157ec4dfbd97b53/curated_tokenizers-0.0.9-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e66aedfeae0c91f3f3e2980b17933b3d08f3fba6c8ba7057b9b05d596e8a0b27", size = 734544, upload-time = "2024-01-18T13:45:18.864Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fb/d6e57b1155bee398f43de58ecdcdda44957e9635183312ac0820a19fc94d/curated_tokenizers-0.0.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2abbb571666a9c9b3a15f9df022e25ed1137e9fa8346788aaa747c00f940a3c6", size = 703466, upload-time = "2024-01-18T13:45:20.051Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/7c/2d24633275f2854c144652ee6ef97ae85d444855b6da5aa1203678541fa5/curated_tokenizers-0.0.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64b9991a9720a0ce8cc72d29791fd73f2cc2bef0241b002fd2a756ec8a629143", size = 706194, upload-time = "2024-01-18T13:45:21.844Z" },
+    { url = "https://files.pythonhosted.org/packages/21/24/12ae8f92d0e319ed07dd9c3ee5d24e71dd6ff3dd8d4dbe2126a6e5cbf7a1/curated_tokenizers-0.0.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:35fb208a01f2b3f22172596915d229859549a2d76e484be976dd728b1ca3bdec", size = 734029, upload-time = "2024-01-18T13:45:23.628Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/fc/776b7464029ea126bf55df2a5edd437178ad8e5c0126f953891dfa603f9c/curated_tokenizers-0.0.9-cp312-cp312-win_amd64.whl", hash = "sha256:209d756694c7fb000a0b642016eb6e71c740cfce293adcbf3384aa2a1e701eb2", size = 731507, upload-time = "2024-01-18T13:45:25.416Z" },
+]
+
+[[package]]
+name = "curated-transformers"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/06/6c12c149a7f737dacc76b4c3949dbc7ff87d622567b86996896ae4d104aa/curated-transformers-0.1.1.tar.gz", hash = "sha256:4671f03314df30efda2ec2b59bc7692ea34fcea44cb65382342c16684e8a2119", size = 16313, upload-time = "2023-05-24T07:29:22.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/67/3b72b3fdfcadab61bc8f59c17e63770e526ffabd583ed32f174a7c01af85/curated_transformers-0.1.1-py2.py3-none-any.whl", hash = "sha256:d716063d73d803c6925d2dab56fde9b9ab8e89e663c2c0587804944ba488ff01", size = 25972, upload-time = "2023-05-24T07:29:21.119Z" },
 ]
 
 [[package]]
@@ -1352,6 +1410,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dlinfo"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/8e/8f2f94cd40af1b51e8e371a83b385d622170d42f98776441a6118f4dd682/dlinfo-2.0.0.tar.gz", hash = "sha256:88a2bc04f51d01bc604cdc9eb1c3cc0bde89057532ca6a3e71a41f6235433e17", size = 12727, upload-time = "2025-01-16T15:43:10.756Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/90/022c79d6e5e6f843268c10b84d4a021ee3afba0621d3c176d3ff2024bfc8/dlinfo-2.0.0-py3-none-any.whl", hash = "sha256:b32cc18e3ea67c0ca9ca409e5b41eed863bd1363dbc9dd3de90fedf11b61e7bc", size = 3654, upload-time = "2025-01-16T15:43:09.474Z" },
+]
+
+[[package]]
 name = "docopt"
 version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1381,6 +1448,19 @@ version = "3.8.0"
 source = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" }
 wheels = [
     { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl", hash = "sha256:1932429db727d4bff3deed6b34cfc05df17794f4a52eeb26cf8928f7c1a0fb85" },
+]
+
+[[package]]
+name = "espeakng-loader"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/92/f44ed7f531143c3c6c97d56e2b0f9be8728dc05e18b96d46eb539230ed46/espeakng_loader-0.2.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b77477ae2ddf62a748e04e49714eabb2f3a24f344166200b00539083bd669904", size = 9938387, upload-time = "2025-01-17T01:22:42.064Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/26/258c0cd43b9bc1043301c5f61767d6a6c3b679df82790c9cb43a3277b865/espeakng_loader-0.2.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d27cdca31112226e7299d8562e889d3e38a1e48055c9ee381b45d669072ee59f", size = 9892565, upload-time = "2025-01-17T01:22:40.365Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1e/25ec5ab07528c0fbb215a61800a38eca05c8a99445515a02d7fa5debcb32/espeakng_loader-0.2.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:08721baf27d13d461f6be6eed9a65277e70d68234ff484fd8b9897b222cdcb6d", size = 10078484, upload-time = "2025-01-17T01:22:43.373Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/ad/1b768d8daffc2996e07bbcb6f534d8de3202cd75fce1f1c45eced1ce6465/espeakng_loader-0.2.4-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:d1e798141b46a050cdb75fcf3c17db969bb2c40394f3f4a48910655d547508b9", size = 10037736, upload-time = "2025-01-17T01:22:42.576Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ed/a3d872fbad4f3a3f3db0e8c31768ab14e77cd77306de16b8b20b1e1df7ea/espeakng_loader-0.2.4-py3-none-win_amd64.whl", hash = "sha256:41f1e08ac9deda2efd1ea9de0b81dab9f5ae3c4b24284f76533d0a7b1dd7abd7", size = 9437292, upload-time = "2025-01-17T01:23:27.463Z" },
+    { url = "https://files.pythonhosted.org/packages/29/64/0b75bc50ec53b4e000bac913625511215aa96124adf5dba8c4baa17c02cd/espeakng_loader-0.2.4-py3-none-win_arm64.whl", hash = "sha256:d7a2928843eaeb2df82f99a370f44e8a630f59b02f9b0d1f168a03c4eeb76b89", size = 9426841, upload-time = "2025-01-17T01:23:21.766Z" },
 ]
 
 [[package]]
@@ -1744,22 +1824,21 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.14.0"
+version = "0.36.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "packaging" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "tqdm" },
-    { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/40/43109e943fd718b0ccd0cd61eb4f1c347df22bf81f5874c6f22adf44bcff/huggingface_hub-1.14.0.tar.gz", hash = "sha256:d6d2c9cd6be1d02ae9ec6672d5587d10a427f377db688e82528f426a041622c2", size = 782365, upload-time = "2026-05-06T14:14:34.278Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/a5/33b49ba7bea7c41bb37f74ec0f8beea0831e052330196633fe2c77516ea6/huggingface_hub-1.14.0-py3-none-any.whl", hash = "sha256:efe075535c62e130b30e836b138e13785f6f043d1f0539e0a39aa411a99e90b8", size = 661479, upload-time = "2026-05-06T14:14:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
 ]
 
 [[package]]
@@ -1841,6 +1920,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
 ]
 
 [[package]]
@@ -2115,6 +2203,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/41/c5f71f9f00aabcc71fee8b7475e3f64747282580c2fe748961ba29b18385/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f6764a4ccab3078db14a632420930f6186058750df066b8ea2a7106df91d3203", size = 138036, upload-time = "2026-03-09T13:15:36.894Z" },
     { url = "https://files.pythonhosted.org/packages/fa/06/7399a607f434119c6e1fdc8ec89a8d51ccccadf3341dee4ead6bd14caaf5/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7", size = 194295, upload-time = "2026-03-09T13:15:38.22Z" },
     { url = "https://files.pythonhosted.org/packages/b5/91/53255615acd2a1eaca307ede3c90eb550bae9c94581f8c00081b6b1c8f44/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:1f1489f769582498610e015a8ef2d36f28f505ab3096d0e16b4858a9ec214f57", size = 75987, upload-time = "2026-03-09T13:15:39.65Z" },
+]
+
+[[package]]
+name = "kokoro"
+version = "0.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "loguru" },
+    { name = "misaki", extra = ["en"] },
+    { name = "numpy" },
+    { name = "torch" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/48/88b8cdf28b068d070195c2817175549dee48e7682e3ab8994bee5f69217e/kokoro-0.9.4.tar.gz", hash = "sha256:fbf633262797f8cf46fdac3315cf9cade67dc8b762c0feccf334892772fb9ac4", size = 26215928, upload-time = "2025-04-05T22:01:35.294Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/cc/75f41633c75224ba820a4533163bc8b070b6bf25416014074c63284c2d4e/kokoro-0.9.4-py3-none-any.whl", hash = "sha256:a129dc6364a286bd6a92c396e9862459d3d3e45f2c15596ed5a94dcee5789efd", size = 32592, upload-time = "2025-04-05T22:01:23.018Z" },
 ]
 
 [[package]]
@@ -2524,6 +2629,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "misaki"
+version = "0.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "addict" },
+    { name = "regex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c7/fb01370a76585b46595a01b52f18e65c8ba6d7a313a05e5d9fff0a8e1c69/misaki-0.9.4.tar.gz", hash = "sha256:3960fa3e6de179a90ee8e628446a4a4f6b8c730b6e3410999cf396189f4d9c40", size = 3756765, upload-time = "2025-04-05T21:57:14.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/ec/0ee4110ddb54278b8f21c40a140370ae8f687036c4edf578316602697c56/misaki-0.9.4-py3-none-any.whl", hash = "sha256:90e2eeb169786c014c429e5058d2ea6bcd02d651f2a24450ba6c9ffc0f8da15a", size = 3617774, upload-time = "2025-04-05T21:57:10.678Z" },
+]
+
+[package.optional-dependencies]
+en = [
+    { name = "espeakng-loader" },
+    { name = "num2words" },
+    { name = "phonemizer-fork" },
+    { name = "spacy" },
+    { name = "spacy-curated-transformers" },
 ]
 
 [[package]]
@@ -2969,6 +3096,18 @@ wheels = [
 ]
 
 [[package]]
+name = "num2words"
+version = "0.5.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docopt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/58/ad645bd38b4b648eb2fc2ba1b909398e54eb0cbb6a7dbd2b4953e38c9621/num2words-0.5.14.tar.gz", hash = "sha256:b066ec18e56b6616a3b38086b5747daafbaa8868b226a36127e0451c0cf379c6", size = 218213, upload-time = "2024-12-17T20:17:10.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/5b/545e9267a1cc080c8a1be2746113a063e34bcdd0f5173fd665a5c13cb234/num2words-0.5.14-py3-none-any.whl", hash = "sha256:1c8e5b00142fc2966fd8d685001e36c4a9911e070d1b120e1beb721fa1edb33d", size = 163525, upload-time = "2024-12-17T20:17:06.074Z" },
+]
+
+[[package]]
 name = "numba"
 version = "0.65.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3380,6 +3519,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "phonemizer-fork"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "dlinfo" },
+    { name = "joblib" },
+    { name = "segments" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/fa/9294d2f11890ca49d0bdac7a4da60cbe5686629bfd4987cae0ad75e051cc/phonemizer_fork-3.3.2.tar.gz", hash = "sha256:10e16e827d0443b087062e21b55e805c00989cf1343b2e81e734cae5f6c0cf69", size = 300989, upload-time = "2025-01-30T13:02:31.201Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/f1/0dcce21b0ae16a82df4b6583f8f3ad8e55b35f7e98b6bf536a4dd225fa08/phonemizer_fork-3.3.2-py3-none-any.whl", hash = "sha256:97305c76f4183b3825dae8f4c032265fe78c9946ce58c47d4b62161349264b74", size = 82700, upload-time = "2025-01-30T13:02:28.667Z" },
 ]
 
 [[package]]
@@ -4669,6 +4824,21 @@ wheels = [
 ]
 
 [[package]]
+name = "sacremoses"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "joblib" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/51/fbdc4af4f6e85d26169e28be3763fe50ddfd0d4bf8b871422b0788dcc4d2/sacremoses-0.1.1.tar.gz", hash = "sha256:b6fd5d3a766b02154ed80b962ddca91e1fd25629c0978c7efba21ebccf663934", size = 883188, upload-time = "2023-10-30T15:56:20.187Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/f0/89ee2bc9da434bd78464f288fdb346bc2932f2ee80a90b2a4bbbac262c74/sacremoses-0.1.1-py3-none-any.whl", hash = "sha256:31e04c98b169bfd902144824d191825cd69220cdb4ae4bcf1ec58a7db5587b1a", size = 897476, upload-time = "2023-10-30T15:56:18.121Z" },
+]
+
+[[package]]
 name = "scikit-learn"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4784,6 +4954,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
+name = "segments"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "csvw" },
+    { name = "regex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/57/85cac3a8e32370e88fa5fa92812edb6025db7fcbed51452bd56ee1524957/segments-2.4.0.tar.gz", hash = "sha256:bba71f5520ddd54c8aa2f4d765a60618c6862162d6e7356a4a097f2223166f5b", size = 18662, upload-time = "2026-03-07T10:01:28.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/60/eef9acce946177f92c9aabf432224d87ab908bafafac516a36ab924199f3/segments-2.4.0-py2.py3-none-any.whl", hash = "sha256:4021dc67f201cc03c864c74c618bdb163b1af629da3040babbaa37d8813f3db0", size = 16321, upload-time = "2026-03-07T10:01:27.885Z" },
 ]
 
 [[package]]
@@ -4997,6 +5180,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/d4/419868afd449bdd367df005932537eea66c71e97c899ba278f3124933f3c/spacy-3.8.14-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:042d799e342fdb6bb5b02a4213a95acc9116c40ed3c849bb0a8296fbe648ec22", size = 31763252, upload-time = "2026-03-29T10:41:15.569Z" },
     { url = "https://files.pythonhosted.org/packages/ec/53/df5c1fee45f200b749ba72eeb536fbb2c545fc56230324954263b2f3be00/spacy-3.8.14-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b2264294097336e86832e8663f1ab3a7215621184863c96c082ab17ee11937", size = 32717872, upload-time = "2026-03-29T10:41:18.193Z" },
     { url = "https://files.pythonhosted.org/packages/12/c2/f1882ec2f5cc9c4e73cf2132997a03c397d7ceeb5ee7f7bb878b51a16365/spacy-3.8.14-cp313-cp313-win_amd64.whl", hash = "sha256:4b6d4f20e291a7c70e37de2f246622b44a0ce82efaa710c9801c6bd599e75177", size = 14220335, upload-time = "2026-03-29T10:41:20.89Z" },
+]
+
+[[package]]
+name = "spacy-curated-transformers"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "curated-tokenizers" },
+    { name = "curated-transformers" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/b3/a4fd3cf28008cbe1d95463b5c76a0d9c8da7b9ad4f06289c2be4aae62052/spacy_curated_transformers-0.3.1.tar.gz", hash = "sha256:7e53fccf64260e641b0a3f2b65b6d98381b86cef6eeb21ce279e8db849e8525d", size = 218990, upload-time = "2025-05-28T10:29:32.69Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d8/f053d43125ae4ad14f3e2a12a475a656128233f1f40a272c6e09a05c73e8/spacy_curated_transformers-0.3.1-py2.py3-none-any.whl", hash = "sha256:503559b6a1d6e44ec2c978e18ed871ce5c3d56871dc9216c0e1523428204e610", size = 237943, upload-time = "2025-05-28T10:29:31.058Z" },
 ]
 
 [[package]]
@@ -5533,6 +5730,27 @@ wheels = [
 ]
 
 [[package]]
+name = "transformers"
+version = "4.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "requests" },
+    { name = "sacremoses" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/33/ac7ad1252c60170c98f0f0e1138bb24f4e361ee1dca6d68110bd3daccf1a/transformers-4.17.0.tar.gz", hash = "sha256:986fd59255460555b893a2b1827b9b8dd4e5cd6343e4409d18539208f69fb51b", size = 3207539, upload-time = "2022-03-03T15:15:26.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/11/07cea2439c82726ee05575472e5b09c3b6eeac7e32eef1a736ad3646a8f0/transformers-4.17.0-py3-none-any.whl", hash = "sha256:5c7d1955693ebf4a69a0fa700b2ef730232d5d7c1528e15d44c1d473b38f57b8", size = 3826358, upload-time = "2022-03-03T15:15:23.275Z" },
+]
+
+[[package]]
 name = "triton"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5643,6 +5861,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/7d/a8a765761bbc0c836e397a2e48d498305a865b70a8600fd7a942e85dcf63/Unidecode-1.4.0.tar.gz", hash = "sha256:ce35985008338b676573023acc382d62c264f307c8f7963733405add37ea2b23", size = 200149, upload-time = "2025-04-24T08:45:03.798Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8f/b7/559f59d57d18b44c6d1250d2eeaa676e028b9c527431f5d0736478a73ba1/Unidecode-1.4.0-py3-none-any.whl", hash = "sha256:c3c7606c27503ad8d501270406e345ddb480a7b5f38827eafe4fa82a137f0021", size = 235837, upload-time = "2025-04-24T08:45:01.609Z" },
+]
+
+[[package]]
+name = "uritemplate"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `champi_stt/providers/kokoro/` — `KokoroConfig`, `KokoroSTTProvider`, `KokoroError` hierarchy
- Registers `"kokoro"` in `factory.py` (`_SUPPORTED_PROVIDERS`, `get_provider()`)
- Adds `[kokoro]` optional extra to `pyproject.toml` (`kokoro>=0.9`) and includes it in `[all]`
- Adds 28 unit tests covering config, lifecycle, all audio input types, error paths, context manager, model info, and factory integration

## Note on Kokoro

The `kokoro` PyPI package (https://github.com/hexgrad/kokoro) is a **TTS** (text-to-speech) library, not STT. However, this implementation follows the issue description in wrapping its `KPipeline.recognize()` method as a speech-recognition interface. If `KPipeline` does not expose a `recognize()` method in the installed version, `KokoroTranscriptionError` is raised with a clear message — the provider is installed as a skeleton that surfaces the limitation at runtime rather than at import time, keeping the factory and `list_providers()` fully functional.

## Acceptance criteria

- [x] `list_providers()` returns `"kokoro"`
- [x] `get_provider("kokoro")` returns a `KokoroSTTProvider` instance
- [x] `KokoroConfig.from_env()` reads `KOKORO_MODEL_ID`, `KOKORO_LANG_CODE`, `KOKORO_DEVICE`
- [x] `get_provider_status("kokoro")` / `get_model_info()` returns useful status info
- [x] Kokoro is an optional install (`champi-stt[kokoro]`)
- [x] Missing `kokoro` package raises `KokoroNotInstalledError` with install instructions

Closes #106